### PR TITLE
[design] toast: 표시 위치, 디자인 변경

### DIFF
--- a/src/app/styles/toast.css
+++ b/src/app/styles/toast.css
@@ -10,39 +10,52 @@
   margin: 0 auto !important;
   word-break: keep-all; /* 단어 단위로 줄바꿈 */
   border-radius: 16px;
-  background-color: white !important;
+  background-color: rgba(248, 250, 252, 0.85) !important;
   padding: 16px 24px !important;
   font-size: 14px;
   font-weight: 500;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
 }
 
+/* default icon */
+.Toastify__close-button {
+  color: #1e293b !important;
+}
+
+.Toastify__toast-icon svg {
+  fill: #1e293b !important;
+}
+
+/* success */
 .Toastify__toast--success {
   color: #10b981 !important;
 }
 
-.Toastify__toast--error {
-  color: #f43f5e !important;
+.Toastify__toast--success .Toastify__close-button {
+  color: #10b981 !important;
 }
 
-.Toastify__close-button {
-  display: none !important;
-}
-
-/* default icon */
-.Toastify__toast-icon svg {
+.Toastify__toast--success .Toastify__toast-icon svg {
   fill: #10b981 !important;
-}
-
-/* type icon */
-.Toastify__toast--error .Toastify__toast-icon svg {
-  fill: #f43f5e !important;
 }
 
 .Toastify__progress-bar--success {
   background: #10b981 !important;
 }
 
+/* error */
+.Toastify__toast--error {
+  color: #ef4444 !important;
+}
+
+.Toastify__toast--error .Toastify__close-button {
+  color: #ef4444 !important;
+}
+
+.Toastify__toast--error .Toastify__toast-icon svg {
+  fill: #ef4444 !important;
+}
+
 .Toastify__progress-bar--error {
-  background: #f43f5e !important;
+  background: #ef4444 !important;
 }

--- a/src/components/common/ToastStyle.tsx
+++ b/src/components/common/ToastStyle.tsx
@@ -7,7 +7,7 @@ const ToastStyle = () => {
   return (
     <ToastContainer
       limit={2}
-      position="bottom-center"
+      position="top-center"
       autoClose={3000}
       newestOnTop={true}
       hideProgressBar={false}


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #79 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
1. 위치 변경: 하단 중앙 -> 상단 중앙
2. 닫기 버튼 활성화
3. 배경 투명도 변경: 100 -> 85

일부 페이지 모바일 버전에서 모달이 하단에 표시되어, 토스트와 겹친다는 의견을 반영해 위치를 top-center로 수정,
상단 표시 시 사용자가 쉽게 닫을 수 있어야 한다는 의견 반영해 닫기 버튼 활성화,
프로젝트 배경 색이 어두워, 토스트 bg의 밝기가 부담스러울 수 있다는 의견 반영해 배경 불투명도 저감했습니다.

<br/>

## 📷 스크린샷
<!--- 없을 시 해당 목차는 삭제합니다. -->
![image](https://github.com/user-attachments/assets/bcfa0fb7-7da7-4a05-a9c6-f6bd96e60c90)
테스트 완료
<br/>
