### PR TITLE
[refactor]/#78/ apis 리팩토링

### DIFF
--- a/src/app/(team)/team/[teamid]/tasklist/_components/DeleteTeamButton.tsx
+++ b/src/app/(team)/team/[teamid]/tasklist/_components/DeleteTeamButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { deleteGroup } from '@/lib/apis/group';
+import { deleteGroupById } from '@/lib/apis/group';
 import { toast } from 'react-toastify';
 
 export default function DeleteTeamButton() {
@@ -8,7 +8,7 @@ export default function DeleteTeamButton() {
 
   const handleDeleteTeam = async () => {
     try {
-      await deleteGroup(groupId);
+      await deleteGroupById(groupId);
 
       toast.success('팀 삭제 성공');
     } catch (error) {

--- a/src/app/(team)/team/[teamid]/tasklist/_components/LoginButton.tsx
+++ b/src/app/(team)/team/[teamid]/tasklist/_components/LoginButton.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import Cookies from 'js-cookie';
-import { postSignIn } from '@/lib/apis/auth';
+import { signIn } from '@/lib/apis/auth';
 import { toast } from 'react-toastify';
 
 export default function LoginButton() {
   const handleLogin = async () => {
     try {
-      const data = await postSignIn({
+      const data = await signIn({
         email: 'test1111@email.com',
         password: 'test1111*',
       });

--- a/src/app/(team)/team/[teamid]/tasklist/_components/TeamInfo.tsx
+++ b/src/app/(team)/team/[teamid]/tasklist/_components/TeamInfo.tsx
@@ -1,11 +1,11 @@
 import { cookies } from 'next/headers';
-import { getGroup } from '@/lib/apis/group';
+import { getGroupById } from '@/lib/apis/group';
 
 export default async function TeamInfo() {
   const token = cookies().get('accessToken')?.value ?? '';
   const groupId = 2200;
 
-  const data = await getGroup({ groupId, token });
+  const data = await getGroupById({ groupId, token });
 
   if (!data) return;
 

--- a/src/lib/apis/article/index.ts
+++ b/src/lib/apis/article/index.ts
@@ -7,6 +7,7 @@ import {
   MessageResponse,
 } from '@/lib/apis/article/type';
 
+// 게시글 생성 (POST /articles)
 export async function postArticle(
   body: ArticleBody
 ): Promise<ArticleResponse | null> {
@@ -26,7 +27,8 @@ export async function postArticle(
   });
 }
 
-export async function getArticleList({
+// 게시글 목록 조회 (GET /articles)
+export async function getArticles({
   page,
   pageSize,
   order,
@@ -51,7 +53,8 @@ export async function getArticleList({
   });
 }
 
-export async function getArticle({
+// 게시글 상세 조회 (GET /articles/:articleId)
+export async function getArticleById({
   articleId,
   token,
 }: {
@@ -65,6 +68,7 @@ export async function getArticle({
   });
 }
 
+// 게시글 수정 (PATCH /articles/:articleId)
 export async function patchArticle({
   articleId,
   body,
@@ -88,6 +92,7 @@ export async function patchArticle({
   });
 }
 
+// 게시글 삭제 (DELETE /articles/:articleId)
 export async function deleteArticle(
   articleId: number
 ): Promise<MessageResponse | null> {
@@ -99,6 +104,7 @@ export async function deleteArticle(
   });
 }
 
+// 게시글 좋아요 등록 (POST /articles/:articleId/like)
 export async function postArticleLike(
   articleId: number
 ): Promise<ArticleResponse | null> {
@@ -110,6 +116,7 @@ export async function postArticleLike(
   });
 }
 
+// 게시글 좋아요 취소 (DELETE /articles/:articleId/like)
 export async function deleteArticleLike(
   articleId: number
 ): Promise<ArticleResponse | null> {

--- a/src/lib/apis/articleComment/index.ts
+++ b/src/lib/apis/articleComment/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@/lib/apis/articleComment/type';
 
 // 게시글 댓글 작성 (POST /articles/:articleId/comments)
-export async function postArticleComment({
+export async function postCommentByArticleId({
   articleId,
   body,
 }: {
@@ -25,7 +25,7 @@ export async function postArticleComment({
 }
 
 // 게시글 댓글 목록 조회 (GET /articles/:articleId/comments)
-export async function getArticleList({
+export async function getCommentsByArticleId({
   articleId,
   limit,
   cursor,
@@ -49,7 +49,7 @@ export async function getArticleList({
 }
 
 // 게시글 댓글 수정 (PATCH /comments/:commentId)
-export async function patchArticleComment({
+export async function patchCommentByArticleId({
   commentId,
   body,
 }: {
@@ -66,7 +66,7 @@ export async function patchArticleComment({
 }
 
 // 게시글 댓글 삭제 (DELETE /comments/:commentId)
-export async function deleteArticleComment(
+export async function deleteCommentByArticleId(
   commentId: number
 ): Promise<MessageResponse | null> {
   const token = Cookies.get('accessToken');

--- a/src/lib/apis/articleComment/index.ts
+++ b/src/lib/apis/articleComment/index.ts
@@ -7,6 +7,7 @@ import {
   MessageResponse,
 } from '@/lib/apis/articleComment/type';
 
+// 게시글 댓글 작성 (POST /articles/:articleId/comments)
 export async function postArticleComment({
   articleId,
   body,
@@ -23,6 +24,7 @@ export async function postArticleComment({
   });
 }
 
+// 게시글 댓글 목록 조회 (GET /articles/:articleId/comments)
 export async function getArticleList({
   articleId,
   limit,
@@ -46,6 +48,7 @@ export async function getArticleList({
   });
 }
 
+// 게시글 댓글 수정 (PATCH /comments/:commentId)
 export async function patchArticleComment({
   commentId,
   body,
@@ -62,6 +65,7 @@ export async function patchArticleComment({
   });
 }
 
+// 게시글 댓글 삭제 (DELETE /comments/:commentId)
 export async function deleteArticleComment(
   commentId: number
 ): Promise<MessageResponse | null> {

--- a/src/lib/apis/auth/index.ts
+++ b/src/lib/apis/auth/index.ts
@@ -7,12 +7,19 @@ import {
   AuthResponse,
 } from '@/lib/apis/auth/type';
 
-// 간편 로그인 App 등록/수정
-export async function postOAuthApp(
-  body: OAuthAppBody
-): Promise<OAuthAppResponse | null> {
-  return fetcher<OAuthAppBody, OAuthAppResponse>({
-    url: '/oauthApps',
+// 회원가입
+export async function signUp(body: AuthBody): Promise<AuthResponse | null> {
+  return fetcher<AuthBody, AuthResponse>({
+    url: '/auth/signUp',
+    method: 'POST',
+    body,
+  });
+}
+
+// 로그인
+export async function signIn(body: AuthBody): Promise<AuthResponse | null> {
+  return fetcher<AuthBody, AuthResponse>({
+    url: '/auth/signIn',
     method: 'POST',
     body,
   });
@@ -27,17 +34,12 @@ export async function postOAuth(body: OAuthBody): Promise<AuthResponse | null> {
   });
 }
 
-export async function postSignUp(body: AuthBody): Promise<AuthResponse | null> {
-  return fetcher<AuthBody, AuthResponse>({
-    url: '/auth/signUp',
-    method: 'POST',
-    body,
-  });
-}
-
-export async function postSignIn(body: AuthBody): Promise<AuthResponse | null> {
-  return fetcher<AuthBody, AuthResponse>({
-    url: '/auth/signIn',
+// 간편 로그인 App 등록/수정
+export async function postOAuthApp(
+  body: OAuthAppBody
+): Promise<OAuthAppResponse | null> {
+  return fetcher<OAuthAppBody, OAuthAppResponse>({
+    url: '/oauthApps',
     method: 'POST',
     body,
   });

--- a/src/lib/apis/comment/index.ts
+++ b/src/lib/apis/comment/index.ts
@@ -2,7 +2,8 @@ import Cookies from 'js-cookie';
 import fetcher from '@/lib/fetcher';
 import { CommentBody, CommentResponse } from '@/lib/apis/comment/type';
 
-export async function getComment({
+// 특정 할 일의 댓글 목록 조회 (GET /tasks/:taskId/comments)
+export async function getCommentsByTaskId({
   taskId,
   token,
 }: {
@@ -16,7 +17,8 @@ export async function getComment({
   });
 }
 
-export async function postComment({
+// 특정 할 일에 댓글 작성 (POST /tasks/:taskId/comments)
+export async function postTaskComment({
   taskId,
   body,
 }: {
@@ -32,7 +34,8 @@ export async function postComment({
   });
 }
 
-export async function patchComment({
+// 특정 댓글 수정 (PATCH /tasks/:taskId/comments/:commentId)
+export async function patchTaskComment({
   taskId,
   commentId,
   body,
@@ -50,7 +53,8 @@ export async function patchComment({
   });
 }
 
-export async function deleteComment({
+// 특정 댓글 삭제 (DELETE /tasks/:taskId/comments/:commentId)
+export async function deleteTaskComment({
   taskId,
   commentId,
 }: {

--- a/src/lib/apis/group/index.ts
+++ b/src/lib/apis/group/index.ts
@@ -10,7 +10,8 @@ import {
 } from '@/lib/apis/group/type';
 import { TaskResponse } from '@/lib/apis/task/type';
 
-export async function getGroup({
+// 그룹 단일 조회 (GET /groups/:id)
+export async function getGroupById({
   groupId,
   token,
 }: {
@@ -24,7 +25,8 @@ export async function getGroup({
   });
 }
 
-export async function patchGroup({
+// 그룹 수정 (PATCH /groups/:id)
+export async function patchGroupById({
   groupId,
   body,
 }: {
@@ -40,7 +42,8 @@ export async function patchGroup({
   });
 }
 
-export async function deleteGroup(groupId: number): Promise<null> {
+// 그룹 삭제 (DELETE /groups/:id)
+export async function deleteGroupById(groupId: number): Promise<null> {
   const token = Cookies.get('accessToken');
   return fetcher<undefined, null>({
     url: `/groups/${groupId}`,
@@ -49,6 +52,7 @@ export async function deleteGroup(groupId: number): Promise<null> {
   });
 }
 
+// 그룹 생성 (POST /groups)
 export async function postGroup(
   body: GroupBody
 ): Promise<GroupResponse | null> {
@@ -67,7 +71,8 @@ export async function postGroup(
   });
 }
 
-export async function getGroupMember({
+// 그룹 멤버 단일 조회 (GET /groups/:id/member/:memberUserId)
+export async function getGroupMemberById({
   groupId,
   memberId,
   token,
@@ -83,7 +88,8 @@ export async function getGroupMember({
   });
 }
 
-export async function deleteGroupMember({
+// 그룹 멤버 삭제 (DELETE /groups/:id/member/:memberUserId)
+export async function deleteGroupMemberById({
   groupId,
   memberId,
 }: {
@@ -98,7 +104,7 @@ export async function deleteGroupMember({
   });
 }
 
-// 초대 링크용 토큰 생성
+// 초대 링크용 토큰 생성 (GET /groups/:id/invitation)
 export async function getGroupInvitation({
   groupId,
   token,
@@ -113,7 +119,7 @@ export async function getGroupInvitation({
   });
 }
 
-// 초대 수락
+// 초대 수락 (POST /groups/accept-invitation)
 export async function postGroupInvitation(
   body: GroupInvitationBody
 ): Promise<GroupInvitationResponse | null> {
@@ -126,6 +132,7 @@ export async function postGroupInvitation(
   });
 }
 
+// 그룹 멤버 추가 (POST /groups/:id/member)
 export async function postGroupMember({
   groupId,
   body,
@@ -142,7 +149,7 @@ export async function postGroupMember({
   });
 }
 
-// 특정 날짜의 할 일 리스트
+// 그룹 할 일 조회 (GET /groups/:id/tasks?date=YYYY-MM-DDT00:00:00Z)
 export async function getGroupTasks({
   groupId,
   date,

--- a/src/lib/apis/user/index.ts
+++ b/src/lib/apis/user/index.ts
@@ -11,6 +11,7 @@ import {
   MessageResponse,
 } from '@/lib/apis/user/type';
 
+// 회원 정보 조회 (GET /user)
 export async function getUser(token: string): Promise<UserResponse | null> {
   return fetcher<undefined, UserResponse>({
     url: `/user`,
@@ -19,6 +20,7 @@ export async function getUser(token: string): Promise<UserResponse | null> {
   });
 }
 
+// 회원 정보 수정 (PATCH /user)
 export async function patchUser(
   body: UserBody
 ): Promise<MessageResponse | null> {
@@ -37,6 +39,7 @@ export async function patchUser(
   });
 }
 
+// 회원 탈퇴 (DELETE /user)
 export async function deleteUser(): Promise<null> {
   const token = Cookies.get('accessToken');
   return fetcher<undefined, null>({
@@ -46,6 +49,7 @@ export async function deleteUser(): Promise<null> {
   });
 }
 
+// 사용자 소속 그룹 조회 (GET /user/groups)
 export async function getUserGroups(
   token: string
 ): Promise<UserGroupResponse[] | null> {
@@ -56,6 +60,7 @@ export async function getUserGroups(
   });
 }
 
+// 사용자 멤버십 정보 조회 (GET /user/memberships)
 export async function getUserMemberships(
   token: string
 ): Promise<UserMembershipResponse[] | null> {
@@ -66,6 +71,7 @@ export async function getUserMemberships(
   });
 }
 
+// 사용자 완료한 작업 조회 (GET /user/history)
 export async function getUserHistory(
   token: string
 ): Promise<UserHistoryResponse | null> {
@@ -76,7 +82,7 @@ export async function getUserHistory(
   });
 }
 
-// 비밀번호 재설정 이메일 전송
+// 비밀번호 재설정 이메일 전송 (POST /user/send-reset-password-email)
 export async function postResetPasswordToEmail(
   body: ResetPasswordToEmailBody
 ): Promise<MessageResponse | null> {
@@ -89,7 +95,7 @@ export async function postResetPasswordToEmail(
   });
 }
 
-// 이메일로 전달받은 링크에서 비밀번호 초기화
+// 이메일로 전달받은 링크에서 비밀번호 초기화 (PATCH /user/reset-password)
 export async function patchResetPassword(
   body: ResetPasswordBody
 ): Promise<MessageResponse | null> {
@@ -102,6 +108,7 @@ export async function patchResetPassword(
   });
 }
 
+// 비밀번호 변경 (PATCH /user/password)
 export async function patchPassword(
   body: ResetPasswordBody
 ): Promise<MessageResponse | null> {


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #78 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
- task와 taskList를 제외한 /lib/apis/* 폴더 내 API 함수명 리팩토링
- 모든 API 함수에 한글 주석 추가
- 리팩토링된 API 함수가 사용되는 컴포넌트 파일 업데이트
  - auth API의 postSignIn → signIn
  - group API의 deleteGroup → deleteGroupById
  - group API의 getGroup → getGroupById

<br/>

## 📷 스크린샷
<!--- 없을 시 해당 목차는 삭제합니다. -->

<br/>

## 📢 공유 사항
<!--- 리뷰어가 알면 좋을 내용이나, 차후 작업 시 참고할 메모를 작성합니다. -->
- API 함수 네이밍 규칙을 일관성 있게 적용했습니다
- 각 API 함수 역할을 명확히 하는 한글 주석을 추가했습니다.
- API 를 사용하는 컴포넌트들을 확인 후, 함수명을 업데이트 했습니다. 

<br/>

## 📚 참고 자료
<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가합니다. -->
api 함수명 작성 시 `동사+대상+세부사항` 구조로 통일하시면 
api 구조와도 1:1 매칭되므로, 유지보수하기 좋습니다. 

추가적으로 [RESTful API 네이밍](https://medium.com/tech-pentasecurity/restful-api-%EB%84%A4%EC%9D%B4%EB%B0%8D-7c81bdb9da63) 도 읽어보시면 도움될 것 같습니다 🙂
