### PR TITLE
[refactor] #91 / 버튼 컴포넌트 neutral 타입 추가

### DIFF
--- a/src/components/common/Button/style.ts
+++ b/src/components/common/Button/style.ts
@@ -3,7 +3,7 @@ export const baseStyles =
 
 export type ButtonVariant = 'primary' | 'secondary' | 'floating';
 export type ButtonStyleType = {
-  primary: 'filled' | 'outlined' | 'danger';
+  primary: 'filled' | 'outlined' | 'danger' | 'neutral';
   secondary: 'filled' | 'outlined';
   floating: 'default' | 'outlined' | 'transparent';
 }[ButtonVariant];
@@ -19,6 +19,8 @@ const primaryStyles: ButtonStyles = {
     'border text-lg-semibold bg-white border-green-700 text-green-700 hover:border-green-800 hover:text-green-800 focus:border-green-900 focus:text-green-900 active:border-green-900 active:text-green-900',
   danger:
     'bg-danger text-lg-semibold text-white hover:bg-red-700 focus:bg-red-800 active:bg-red-800',
+  neutral:
+    'border text-lg-semibold bg-white border-slate-300 text-slate-500 hover:border-slate-700 hover:text-slate-700 focus:border-slate-900 focus:text-slate-900 active:border-slate-900 active:text-slate-900',
 };
 
 const secondaryStyles: ButtonStyles = {


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #91

<br/>

## 📋 작업 사항
버튼 컴포넌트 작업 중 누락되었던 neutral 타입을 추가했습니다.
주로 `danger` 버튼 옆에 닫기 버튼으로 사용됩니다.

<br/>

## 📷 스크린샷
![스크린샷 2025-04-26 210337](https://github.com/user-attachments/assets/aec1d2e6-495d-43b5-a71c-cc9d52a648b3)


<br/>

## 📢 공유 사항
노션 `버튼 컴포넌트 사용 방법` 회고 부분에 해당 내용도 업데이트 했습니다.

