### PR TITLE
[refactor] InputTextarea: base 모드 추가 & reply 모드에 버튼 배치, onClick prop 추가

### DIFF
--- a/src/components/common/Input/InputTextarea/index.tsx
+++ b/src/components/common/Input/InputTextarea/index.tsx
@@ -36,7 +36,7 @@ const InputTextarea = ({
           'w-full resize-none overflow-hidden focus:outline-none', // base style
 
           variant === 'box' &&
-            'rounded-[12px] border border-slate-50/10 bg-slate-800 focus:border-green-800',
+            'rounded-[12px] border border-slate-50/10 bg-slate-800',
 
           variant === 'reply' && 'border-t border-b border-slate-50/10',
           className

--- a/src/components/common/Input/InputTextarea/index.tsx
+++ b/src/components/common/Input/InputTextarea/index.tsx
@@ -1,19 +1,19 @@
 'use client';
 import React, { useRef } from 'react';
+import clsx from 'clsx';
+import IconRenderer from '@/components/common/Icons/IconRenderer';
 
 interface InputBoxProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
-  variant?: 'box' | 'reply';
-  rightIcon?: React.ReactNode;
+  variant?: 'base' | 'box' | 'reply'; // 할 일 댓글 수정 | 자유게시판 | 할 일 댓글 작성
   className?: string;
-  iconClassName?: string;
+  onClick?: () => void;
 }
 
 const InputTextarea = ({
   variant,
-  rightIcon,
   className = '',
-  iconClassName = '',
+  onClick,
   ...props
 }: InputBoxProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -32,15 +32,23 @@ const InputTextarea = ({
         {...props}
         ref={textareaRef}
         onInput={handleInput}
-        rows={1}
-        className={`w-full resize-none overflow-hidden border-slate-50/10 focus:outline-none ${
-          variant === 'box'
-            ? 'rounded-[12px] border focus:border-green-800'
-            : 'border-t border-b'
-        } ${className}`}
+        className={clsx(
+          'w-full resize-none overflow-hidden focus:outline-none',
+
+          variant === 'box' &&
+            'rounded-[12px] border border-slate-50/10 bg-slate-800 focus:border-green-800',
+
+          variant === 'reply' && 'border-t border-b border-slate-50/10',
+          className
+        )}
       />
-      {rightIcon && (
-        <span className={`absolute ${iconClassName} `}>{rightIcon}</span>
+      {variant === 'reply' && (
+        <button
+          onClick={onClick}
+          className="absolute top-3 right-3 flex size-6 items-center justify-center rounded-full bg-green-700"
+        >
+          <IconRenderer name="ArrowTopIcon" size={16} />
+        </button>
       )}
     </div>
   );

--- a/src/components/common/Input/InputTextarea/index.tsx
+++ b/src/components/common/Input/InputTextarea/index.tsx
@@ -38,14 +38,14 @@ const InputTextarea = ({
           variant === 'box' &&
             'rounded-[12px] border border-slate-50/10 bg-slate-800',
 
-          variant === 'reply' && 'border-t border-b border-slate-50/10',
+          variant === 'reply' && 'border-t border-b border-slate-50/10 py-3',
           className
         )}
       />
       {variant === 'reply' && (
         <button
           onClick={onClick}
-          className="absolute top-3 right-3 flex size-6 items-center justify-center rounded-full bg-green-700"
+          className="absolute top-3 right-0 flex size-6 items-center justify-center rounded-full bg-green-700"
         >
           <IconRenderer name="ArrowTopIcon" size={16} />
         </button>

--- a/src/components/common/Input/InputTextarea/index.tsx
+++ b/src/components/common/Input/InputTextarea/index.tsx
@@ -3,7 +3,7 @@ import React, { useRef } from 'react';
 import clsx from 'clsx';
 import IconRenderer from '@/components/common/Icons/IconRenderer';
 
-interface InputBoxProps
+interface InputTextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   variant?: 'base' | 'box' | 'reply'; // 할 일 댓글 수정 | 자유게시판 | 할 일 댓글 작성
   className?: string;
@@ -15,7 +15,7 @@ const InputTextarea = ({
   className = '',
   onClick,
   ...props
-}: InputBoxProps) => {
+}: InputTextareaProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleInput = () => {
@@ -33,7 +33,7 @@ const InputTextarea = ({
         ref={textareaRef}
         onInput={handleInput}
         className={clsx(
-          'w-full resize-none overflow-hidden focus:outline-none',
+          'w-full resize-none overflow-hidden focus:outline-none', // base style
 
           variant === 'box' &&
             'rounded-[12px] border border-slate-50/10 bg-slate-800 focus:border-green-800',

--- a/src/components/common/Input/InputTextarea/index.tsx
+++ b/src/components/common/Input/InputTextarea/index.tsx
@@ -45,7 +45,13 @@ const InputTextarea = ({
       {variant === 'reply' && (
         <button
           onClick={onClick}
-          className="absolute top-3 right-0 flex size-6 items-center justify-center rounded-full bg-green-700"
+          className={clsx(
+            'absolute top-3 right-0',
+            'flex items-center justify-center',
+            'size-6 rounded-full bg-green-700',
+            'transition-colors duration-100 hover:bg-green-800 focus:bg-green-900 active:bg-green-900',
+            'disabled:cursor-default disabled:bg-slate-400'
+          )}
         >
           <IconRenderer name="ArrowTopIcon" size={16} />
         </button>


### PR DESCRIPTION
…k prop 추가

## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #86 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
1. `base mode` 추가: 고정 스타일 없는 기본 모드(할 일 상세 페이지의 댓글 수정 구현 시 사용)
2. `reply mode` 변경: submit 버튼 배치 및 onClick prop 추가(특정 페이지에서만 사용되어, 스타일 고정 요청받고 작업)
3. rows 고정값 제거: [기존] className prop에 min-h-[n]로 기본 높이 조절 -> [변경] rows={n}로 기본 높이 조절
4. `box mode` 변경: bg 고정값 추가(slate-800), focus 효과 고정값 제거

<br/>

## 📷 스크린샷
<!--- 없을 시 해당 목차는 삭제합니다. -->
![image](https://github.com/user-attachments/assets/93612517-a7d7-43d3-a58e-03850514fe7b)
테스트 완료

<br/>

## 📚 참고 자료
<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가합니다. -->
- 예제 코드
```
        <InputTextarea
          variant="reply"
          rows={1}
          placeholder="댓글을 입력해 주세요"
          className="pr-8"
          onClick={handleClick}
        />
```