### PR TITLE
[feat, refactor] #89 TaskListMenu: 할 일 목록 생성/수정/삭제 기능 추가 / Modal: 리퀘스트 바디 관련 상태 추가

### DIFF
--- a/src/app/(team)/team/[teamid]/task/[taskid]/_components/TaskCommentSection/EditableTaskCommentCard/index.tsx
+++ b/src/app/(team)/team/[teamid]/task/[taskid]/_components/TaskCommentSection/EditableTaskCommentCard/index.tsx
@@ -23,7 +23,7 @@ export default function EditableTaskCommentCard({
       });
       exitCommentEditMode();
     } catch (error) {
-      console.log('Failed to update the comment on the task :', error);
+      console.error('Failed to update the comment on the task :', error);
     }
   };
 

--- a/src/app/(team)/team/[teamid]/task/[taskid]/_components/TaskCommentSection/TaskCommentCard/CommentMenu/index.tsx
+++ b/src/app/(team)/team/[teamid]/task/[taskid]/_components/TaskCommentSection/TaskCommentCard/CommentMenu/index.tsx
@@ -26,7 +26,7 @@ export default function CommentMenu({
     try {
       await deleteTaskComment({ commentId, tag: ['task-comment'] });
     } catch (error) {
-      console.log('Failed to delete the comment on the task :', error);
+      console.error('Failed to delete the comment on the task :', error);
     }
   };
 

--- a/src/app/(team)/team/[teamid]/task/[taskid]/_components/TaskCommentSection/TaskCommentInput/index.tsx
+++ b/src/app/(team)/team/[teamid]/task/[taskid]/_components/TaskCommentSection/TaskCommentInput/index.tsx
@@ -20,7 +20,7 @@ export default function TaskCommentInput() {
       });
       setComment('');
     } catch (error) {
-      console.log('Failed to update the comment on the task :', error);
+      console.error('Failed to update the comment on the task :', error);
     }
   };
 

--- a/src/app/(team)/team/[teamid]/tasklist/page.tsx
+++ b/src/app/(team)/team/[teamid]/tasklist/page.tsx
@@ -22,9 +22,10 @@ export default async function TaskListPage({
   const selectedId = Number(searchParams.id);
   const selectedDate = searchParams.date;
 
-  const groupData = await getGroupById({ groupId });
+  const groupData = await getGroupById({ groupId, tag: ['tasklist'] });
   const taskListsData = groupData?.taskLists ?? [];
   const membersData = groupData?.members ?? [];
+
   const selectedTaskListData = await getTaskListById({
     taskListId: selectedId,
     date: selectedDate,
@@ -44,6 +45,9 @@ export default async function TaskListPage({
           <TaskListMenu
             membersData={membersData}
             userId={Number(userId)}
+            groupId={groupId}
+            taskListId={selectedId}
+            taskListName={selectedTaskListData?.name ?? ''}
             size="md"
           />
         </div>

--- a/src/components/common/Modal/content/CreateTaskListModal/index.tsx
+++ b/src/components/common/Modal/content/CreateTaskListModal/index.tsx
@@ -1,9 +1,40 @@
+import { useState, useEffect } from 'react';
+import { useModalStore } from '@/store/useModalStore';
 import InputBase from '@/components/common/Input/InputBase';
 
 export default function CreateTaskListModal() {
+  const [name, setName] = useState('');
+  const [isSubmitValid, setIsSubmitValid] = useState(false);
+
+  const { setRequestBody, setIsButtonDisabled } = useModalStore();
+
+  useEffect(() => {
+    const trimmedName = name.trim();
+
+    if (trimmedName !== '') {
+      setIsSubmitValid(true);
+    } else {
+      setIsSubmitValid(false);
+    }
+
+    setRequestBody({
+      name: trimmedName,
+    });
+  }, [name]);
+
+  useEffect(() => {
+    setIsButtonDisabled(!isSubmitValid);
+  }, [isSubmitValid]);
+
   return (
     <div>
-      <InputBase placeholder="목록 명을 입력해주세요." />
+      <InputBase
+        value={name}
+        onChange={(e) => {
+          setName(e.target.value);
+        }}
+        placeholder="목록 이름을 입력해주세요."
+      />
     </div>
   );
 }

--- a/src/components/common/Modal/content/EditTaskListModal/index.tsx
+++ b/src/components/common/Modal/content/EditTaskListModal/index.tsx
@@ -1,9 +1,44 @@
+import { useState, useEffect } from 'react';
+import { useModalStore } from '@/store/useModalStore';
 import InputBase from '@/components/common/Input/InputBase';
 
-export default function EditTaskListModal() {
+export default function EditTaskListModal({
+  taskListName,
+}: {
+  taskListName: string;
+}) {
+  const [editedName, setEditedName] = useState(taskListName);
+  const [isEditValid, setIsEditValid] = useState(false);
+
+  const { setRequestBody, setIsButtonDisabled } = useModalStore();
+
+  useEffect(() => {
+    const trimmedName = editedName.trim();
+
+    if (trimmedName !== '' && trimmedName !== taskListName) {
+      setIsEditValid(true);
+    } else {
+      setIsEditValid(false);
+    }
+
+    setRequestBody({
+      name: trimmedName,
+    });
+  }, [editedName]);
+
+  useEffect(() => {
+    setIsButtonDisabled(!isEditValid);
+  }, [isEditValid]);
+
   return (
     <div>
-      <InputBase placeholder="목록 명을 입력해주세요." />
+      <InputBase
+        value={editedName}
+        onChange={(e) => {
+          setEditedName(e.target.value);
+        }}
+        placeholder="목록 이름을 입력해주세요."
+      />
     </div>
   );
 }

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -64,7 +64,11 @@ export default function Modal() {
                   variant === 'taskForm' ? 'gap-4' : 'gap-2'
                 )}
               >
-                {title && <div className="text-lg-medium">{title}</div>}
+                {title && (
+                  <div className="text-lg-medium text-center whitespace-pre-line">
+                    {title}
+                  </div>
+                )}
                 {description && (
                   <div
                     className={clsx(

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -12,6 +12,7 @@ export default function Modal() {
   const {
     options: { variant = 'default', title, description, button },
     content,
+    requestBody,
     isButtonDisabled,
     closeModal,
   } = useModalStore();
@@ -25,7 +26,7 @@ export default function Modal() {
   if (!isModalOpen) return null;
 
   const handleRequest = () => {
-    button?.onRequest();
+    button?.onRequest?.(requestBody);
     closeModal();
   };
 

--- a/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
+++ b/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
@@ -1,0 +1,12 @@
+import { deleteTaskListById } from '@/lib/apis/taskList';
+
+export const handleDeleteTaskList = async (taskListId: number) => {
+  try {
+    await deleteTaskListById({
+      taskListId,
+      tag: ['tasklist'],
+    });
+  } catch (error) {
+    console.log('Failed to delete the task list :', error);
+  }
+};

--- a/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
+++ b/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
@@ -16,7 +16,7 @@ export const handleCreateTaskList = async (
       tag: ['tasklist'],
     });
   } catch (error) {
-    console.log('Failed to create the task list :', error);
+    console.error('Failed to create the task list :', error);
   }
 };
 
@@ -33,7 +33,7 @@ export const handleEditTaskList = async (
       tag: ['tasklist'],
     });
   } catch (error) {
-    console.log('Failed to edit the task list :', error);
+    console.error('Failed to edit the task list :', error);
   }
 };
 
@@ -44,6 +44,6 @@ export const handleDeleteTaskList = async (taskListId: number) => {
       tag: ['tasklist'],
     });
   } catch (error) {
-    console.log('Failed to delete the task list :', error);
+    console.error('Failed to delete the task list :', error);
   }
 };

--- a/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
+++ b/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
@@ -1,4 +1,37 @@
-import { deleteTaskListById } from '@/lib/apis/taskList';
+import { TaskListBody } from '@/lib/apis/taskList/type';
+import {
+  postTaskList,
+  patchTaskListById,
+  deleteTaskListById,
+} from '@/lib/apis/taskList';
+
+export const handleCreateTaskList = async (
+  groupId: number,
+  body: TaskListBody
+) => {
+  try {
+    await postTaskList({
+      groupId,
+      body,
+      tag: ['tasklist'],
+    });
+  } catch (error) {
+    console.log('Failed to create the task list :', error);
+  }
+};
+
+// export const handleEditTaskList = async (taskListId: number) => {
+//   try {
+//     await patchTaskListById({
+//       groupId,
+//       taskListId,
+//       body,
+//       tag: ['tasklist'],
+//     });
+//   } catch (error) {
+//     console.log('Failed to edit the task list :', error);
+//   }
+// };
 
 export const handleDeleteTaskList = async (taskListId: number) => {
   try {

--- a/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
+++ b/src/components/tasklist/TaskListMenu/actions/taskListActions.ts
@@ -20,18 +20,22 @@ export const handleCreateTaskList = async (
   }
 };
 
-// export const handleEditTaskList = async (taskListId: number) => {
-//   try {
-//     await patchTaskListById({
-//       groupId,
-//       taskListId,
-//       body,
-//       tag: ['tasklist'],
-//     });
-//   } catch (error) {
-//     console.log('Failed to edit the task list :', error);
-//   }
-// };
+export const handleEditTaskList = async (
+  groupId: number,
+  taskListId: number,
+  body: TaskListBody
+) => {
+  try {
+    await patchTaskListById({
+      groupId,
+      taskListId,
+      body,
+      tag: ['tasklist'],
+    });
+  } catch (error) {
+    console.log('Failed to edit the task list :', error);
+  }
+};
 
 export const handleDeleteTaskList = async (taskListId: number) => {
   try {

--- a/src/components/tasklist/TaskListMenu/index.tsx
+++ b/src/components/tasklist/TaskListMenu/index.tsx
@@ -10,6 +10,7 @@ import EditTaskListModal from '@/components/common/Modal/content/EditTaskListMod
 import {
   handleCreateTaskList,
   handleDeleteTaskList,
+  handleEditTaskList,
 } from '@/components/tasklist/TaskListMenu/actions/taskListActions';
 
 interface TaskListMenuProps {
@@ -60,10 +61,10 @@ export default function TaskListMenu({
         button: {
           number: 1,
           text: '수정하기',
-          onRequest: () => {},
+          onRequest: (body) => handleEditTaskList(groupId, taskListId, body),
         },
       },
-      <EditTaskListModal />
+      <EditTaskListModal taskListName={taskListName} />
     );
   };
 

--- a/src/components/tasklist/TaskListMenu/index.tsx
+++ b/src/components/tasklist/TaskListMenu/index.tsx
@@ -7,7 +7,10 @@ import DropDown from '@/components/common/Dropdown';
 import TaskListMenuButton from '@/components/tasklist/TaskListMenu/TaskListMenuButton';
 import CreateTaskListModal from '@/components/common/Modal/content/CreateTaskListModal';
 import EditTaskListModal from '@/components/common/Modal/content/EditTaskListModal';
-import { handleDeleteTaskList } from '@/components/tasklist/TaskListMenu/actions/taskListActions';
+import {
+  handleCreateTaskList,
+  handleDeleteTaskList,
+} from '@/components/tasklist/TaskListMenu/actions/taskListActions';
 
 interface TaskListMenuProps {
   membersData: GroupMemberResponse[];
@@ -42,7 +45,7 @@ export default function TaskListMenu({
         button: {
           number: 1,
           text: '만들기',
-          onRequest: () => {},
+          onRequest: (body) => handleCreateTaskList(groupId, body),
         },
       },
       <CreateTaskListModal />

--- a/src/components/tasklist/TaskListMenu/index.tsx
+++ b/src/components/tasklist/TaskListMenu/index.tsx
@@ -1,23 +1,32 @@
 'use client';
 
-import { GroupMemberResponse } from '@/lib/apis/group/type';
+import { useRouter } from 'next/navigation';
 import { useModalStore } from '@/store/useModalStore';
+import { GroupMemberResponse } from '@/lib/apis/group/type';
 import DropDown from '@/components/common/Dropdown';
 import TaskListMenuButton from '@/components/tasklist/TaskListMenu/TaskListMenuButton';
 import CreateTaskListModal from '@/components/common/Modal/content/CreateTaskListModal';
 import EditTaskListModal from '@/components/common/Modal/content/EditTaskListModal';
+import { handleDeleteTaskList } from '@/components/tasklist/TaskListMenu/actions/taskListActions';
 
 interface TaskListMenuProps {
   membersData: GroupMemberResponse[];
   userId: number;
+  groupId: number;
+  taskListId: number;
+  taskListName: string;
   size: 'sm' | 'md';
 }
 
 export default function TaskListMenu({
   membersData,
   userId,
+  groupId,
+  taskListId,
+  taskListName,
   size,
 }: TaskListMenuProps) {
+  const router = useRouter();
   const { openModal } = useModalStore();
 
   const userData = membersData.find((member) => {
@@ -54,8 +63,24 @@ export default function TaskListMenu({
       <EditTaskListModal />
     );
   };
-  // 추후에 할 일 삭제 API 연결 예정
-  const handleDeleteTaskList = () => console.log('삭제하기');
+
+  const openDeleteTaskListModal = () => {
+    openModal({
+      variant: 'danger',
+      title: `'${taskListName}'\n할 일 목록을 정말 삭제하시겠어요?`,
+      description: '삭제 후에는 되돌릴 수 없습니다.',
+      button: {
+        number: 2,
+        text: '삭제하기',
+        onRequest: () => {
+          handleDeleteTaskList(taskListId);
+          if (size === 'md') {
+            router.push(`/team/${groupId}`);
+          }
+        },
+      },
+    });
+  };
 
   return (
     isAdmin && (
@@ -70,7 +95,9 @@ export default function TaskListMenu({
           <DropDown.Item onClick={openEditTaskListModal}>
             수정하기
           </DropDown.Item>
-          <DropDown.Item onClick={handleDeleteTaskList}>삭제하기</DropDown.Item>
+          <DropDown.Item onClick={openDeleteTaskListModal}>
+            삭제하기
+          </DropDown.Item>
         </DropDown.Menu>
       </DropDown>
     )

--- a/src/components/tasklist/TaskListMenu/index.tsx
+++ b/src/components/tasklist/TaskListMenu/index.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from 'next/navigation';
 import { useModalStore } from '@/store/useModalStore';
 import { GroupMemberResponse } from '@/lib/apis/group/type';
+import { TaskListBody } from '@/lib/apis/taskList/type';
 import DropDown from '@/components/common/Dropdown';
 import TaskListMenuButton from '@/components/tasklist/TaskListMenu/TaskListMenuButton';
 import CreateTaskListModal from '@/components/common/Modal/content/CreateTaskListModal';
@@ -46,7 +47,8 @@ export default function TaskListMenu({
         button: {
           number: 1,
           text: '만들기',
-          onRequest: (body) => handleCreateTaskList(groupId, body),
+          onRequest: (body) =>
+            handleCreateTaskList(groupId, body as TaskListBody),
         },
       },
       <CreateTaskListModal />
@@ -61,7 +63,8 @@ export default function TaskListMenu({
         button: {
           number: 1,
           text: '수정하기',
-          onRequest: (body) => handleEditTaskList(groupId, taskListId, body),
+          onRequest: (body) =>
+            handleEditTaskList(groupId, taskListId, body as TaskListBody),
         },
       },
       <EditTaskListModal taskListName={taskListName} />

--- a/src/lib/apis/taskList/index.ts
+++ b/src/lib/apis/taskList/index.ts
@@ -28,15 +28,18 @@ export async function patchTaskListById({
   groupId,
   taskListId,
   body,
+  tag,
 }: {
   groupId: number;
   taskListId: number;
   body: TaskListBody;
+  tag?: string[];
 }): Promise<TaskListResponse | null> {
-  return clientFetcher<TaskListBody, TaskListResponse>({
+  return serverFetcher<TaskListBody, TaskListResponse>({
     url: `/groups/${groupId}/task-lists/${taskListId}`,
     method: 'PATCH',
     body,
+    tag,
   });
 }
 
@@ -59,14 +62,17 @@ export async function deleteTaskListById({
 export async function postTaskList({
   groupId,
   body,
+  tag,
 }: {
   groupId: number;
   body: TaskListBody;
+  tag?: string[];
 }): Promise<TaskListResponse | null> {
-  return clientFetcher<TaskListBody, TaskListResponse>({
+  return serverFetcher<TaskListBody, TaskListResponse>({
     url: `/groups/${groupId}/task-lists`,
     method: 'POST',
     body,
+    tag,
   });
 }
 

--- a/src/lib/apis/taskList/index.ts
+++ b/src/lib/apis/taskList/index.ts
@@ -43,12 +43,15 @@ export async function patchTaskListById({
 // 할 일 목록 삭제 (DELETE /groups/:groupId/task-lists/:id)
 export async function deleteTaskListById({
   taskListId,
+  tag,
 }: {
   taskListId: number;
+  tag?: string[];
 }): Promise<null> {
-  return clientFetcher<undefined, null>({
+  return serverFetcher<undefined, null>({
     url: `/groups/{groupId}/task-lists/${taskListId}`,
     method: 'DELETE',
+    tag,
   });
 }
 

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -8,13 +8,15 @@ interface ModalOptions {
   button?: {
     number: 1 | 2;
     text: string;
-    onRequest: () => void;
+    onRequest: (body?: any) => void;
   };
 }
 
 interface ModalState {
   options: ModalOptions;
   content: ReactNode | null;
+  requestBody: any;
+  setRequestBody: (body: any) => void;
   isButtonDisabled: boolean;
   setIsButtonDisabled: (isValid: boolean) => void;
   openModal: (options: ModalOptions, content?: ReactNode) => void;
@@ -24,9 +26,16 @@ interface ModalState {
 export const useModalStore = create<ModalState>((set) => ({
   options: {},
   content: null,
+  requestBody: null,
+  setRequestBody: (body) => set({ requestBody: body }),
   isButtonDisabled: false,
   setIsButtonDisabled: (isButtonDisabled) => set({ isButtonDisabled }),
   openModal: (options, content) => set({ options, content }),
   closeModal: () =>
-    set({ options: {}, content: null, isButtonDisabled: false }),
+    set({
+      options: {},
+      content: null,
+      requestBody: null,
+      isButtonDisabled: false,
+    }),
 }));

--- a/src/store/useModalStore.ts
+++ b/src/store/useModalStore.ts
@@ -8,15 +8,15 @@ interface ModalOptions {
   button?: {
     number: 1 | 2;
     text: string;
-    onRequest: (body?: any) => void;
+    onRequest: (body?: unknown) => void;
   };
 }
 
 interface ModalState {
   options: ModalOptions;
   content: ReactNode | null;
-  requestBody: any;
-  setRequestBody: (body: any) => void;
+  requestBody: unknown;
+  setRequestBody: (body: unknown) => void;
   isButtonDisabled: boolean;
   setIsButtonDisabled: (isValid: boolean) => void;
   openModal: (options: ModalOptions, content?: ReactNode) => void;


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
#89 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
### TaskListMenu
#### 할 일 목록 생성
- '생성하기' 클릭 시 할 일 목록 생성 모달 표시
- 사용자가 Input에 제목 입력 시 '만들기' 버튼 활성화
- 활성화된 '만들기' 버튼 클릭 시 할 일 목록 생성 후 화면에 바로 반영

#### 할 일 목록 수정
- '수정하기' 클릭 시 할 일 목록 수정 모달 표시
- 사용자가 Input에 제목 입력 및 기존 제목과 새로 입력한 제목이 다를 시 '수정하기' 버튼 활성화
- 활성화된 '수정하기' 버튼 클릭 시 할 일 목록 수정 후 화면에 바로 반영

#### 할 일 목록 삭제
- '삭제하기' 클릭 시 할 일 목록 삭제 모달 표시
- 할 일 목록 삭제 모달의 '삭제하기' 버튼 클릭 시 할 일 목록 삭제 후 팀 페이지로 이동

### Modal
#### 리퀘스트 바디 관련 상태 추가 이유
기존 모달에서는 모달 내용 컴포넌트의 form에 입력한 값을 `button.onRequest()`에 전달하여 API 리퀘스트 body로 넣어줄 방법이 없었다.
그래서 입력 값(body)을 모달 전역 상태에 저장하고 버튼 클릭 시 API 리퀘스트에 넣어 사용할 수 있도록 리퀘스트 바디 관련 상태를 추가하게 되었다.
- **`requestBody` :** 모달 콘텐츠에서 입력 중인 실제 값
- **`setRequestBody` :** `requestBody`를 모달 콘텐츠에 저장하기 위한 함수

<br/>

## 📷 스크린샷
<!--- 없을 시 해당 목차는 삭제합니다. -->
### 할 일 목록 CRUD

https://github.com/user-attachments/assets/d3062369-6abc-403a-861f-08d19bf79d76




<br/>

## 📢 공유 사항
<!--- 리뷰어가 알면 좋을 내용이나, 차후 작업 시 참고할 메모를 작성합니다. -->
#### 추후 작업할 수도 있는 내용
- 할 일 목록 생성 후 생성한 할 일 목록 경로로 이동
- 할 일 목록 삭제 후 팀 페이지가 아닌 첫 번째 할 일 목록 경로로 이동

<br/>

## 📚 참고 자료
<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가합니다. -->
### 모달 사용법
이번에 모달에 상태를 추가하면서 사용법에 변경된 부분이 있으니 아래 노션 페이지 참고 부탁드립니다!
https://www.notion.so/1e7d81d96a378085bd43edecd1064f7a
