### PR TITLE
[feat, design] #155 회원가입(SignupForm): UI 레이아웃 / 유효성 검사 / API 연동 구현

### DIFF
--- a/src/app/(auth)/login/_components/LoginForm/index.tsx
+++ b/src/app/(auth)/login/_components/LoginForm/index.tsx
@@ -1,31 +1,61 @@
 'use client';
 
 import ForgotPasswordButton from '@/app/(auth)/login/_components/LoginForm/ForgotPasswordButton';
-import InputWithLabel from '@/app/(auth)/login/_components/LoginForm/InputWithLabel';
+import InputWithLabel from '@/components/auth/InputWithLabel';
 import Button from '@/components/common/Button';
 import { signIn } from '@/lib/apis/auth';
-import { validateEmail, validatePassword } from '@/utils/inputValidation';
+import {
+  validateEmail,
+  validateName,
+  validatePassword,
+  validatePasswordConfirm,
+} from '@/utils/inputValidation';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 import Cookies from 'js-cookie';
 
 import { z } from 'zod';
 import { useRouter } from 'next/navigation';
+import { InputType } from '@/components/auth/type';
 
 // schema
 const inputEmptySchema = z.object({
   email: z.string().nonempty({ message: '이메일은 필수 입력입니다.' }),
   password: z.string().nonempty({ message: '비밀번호는 필수 입력입니다.' }),
+  userName: z.string().nonempty({ message: '이름은 필수 입력입니다.' }),
+  passwordConfirm: z
+    .string()
+    .nonempty({ message: '비밀번호 확인은 필수 입력입니다.' }),
 });
 
-const inputValidSchema = z.object({
-  email: z.string().refine(validateEmail, {
-    message: '올바른 이메일 형식이 아닙니다.',
-  }),
-  password: z.string().refine(validatePassword, {
-    message: '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.',
-  }),
-});
+const inputValidSchema = z
+  .object({
+    email: z.string().refine(validateEmail, {
+      message: '올바른 이메일 형식이 아닙니다.',
+    }),
+    password: z.string().refine(validatePassword, {
+      message:
+        '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.',
+    }),
+    userName: z.string().refine(validateName, {
+      message: '이름은 10자 이하로 입력해주세요.',
+    }),
+    passwordConfirm: z.string(), // 기본 정의
+  })
+
+  // 외부 유효성 검사 함수를 직접 호출해서 사용
+  // ctx : Zod 내부 컨텍스트
+  .superRefine(({ password, passwordConfirm }, ctx) => {
+    const isMatch = validatePasswordConfirm({ password, passwordConfirm });
+
+    if (!isMatch) {
+      ctx.addIssue({
+        path: ['passwordConfirm'],
+        code: z.ZodIssueCode.custom, // 반드시 enum 값이어야 함
+        message: '비밀번호가 일치하지 않습니다.',
+      });
+    }
+  });
 
 export default function LoginForm() {
   const [formValues, setFormValues] = useState<{
@@ -56,7 +86,7 @@ export default function LoginForm() {
   };
 
   const handleInputBlur =
-    (key: 'email' | 'password') => (e: React.ChangeEvent<HTMLInputElement>) => {
+    (key: InputType) => (e: React.ChangeEvent<HTMLInputElement>) => {
       const newFormValues = { ...formValues, [key]: e.target.value };
       setFormValues(newFormValues);
 
@@ -78,7 +108,7 @@ export default function LoginForm() {
     };
 
   const handleInputChange =
-    (key: 'email' | 'password') => (e: React.ChangeEvent<HTMLInputElement>) => {
+    (key: InputType) => (e: React.ChangeEvent<HTMLInputElement>) => {
       const newFormValues = { ...formValues, [key]: e.target.value };
       const result = inputValidSchema.safeParse(newFormValues);
 

--- a/src/app/(auth)/login/_components/LoginForm/index.tsx
+++ b/src/app/(auth)/login/_components/LoginForm/index.tsx
@@ -10,7 +10,7 @@ import {
   validatePassword,
   validatePasswordConfirm,
 } from '@/utils/inputValidation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import Cookies from 'js-cookie';
 
@@ -76,14 +76,14 @@ export default function LoginForm() {
 
   const router = useRouter();
 
-  const isFormValid = () => {
+  const isFormValid = useMemo(() => {
     return (
       formValues.email !== '' &&
       formValues.password !== '' &&
       (formErrors.email?.length ?? 0) === 0 &&
       (formErrors.password?.length ?? 0) === 0
     );
-  };
+  }, [formValues, formErrors]);
 
   const handleInputBlur =
     (key: InputType) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -131,7 +131,7 @@ export default function LoginForm() {
   const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!isFormValid()) return;
+    if (!isFormValid) return;
 
     try {
       const data = await signIn({
@@ -213,7 +213,7 @@ export default function LoginForm() {
         styleType="filled"
         radius="sm"
         className="w-[460px]"
-        disabled={!isFormValid()}
+        disabled={!isFormValid}
       >
         로그인
       </Button>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import SocialLogin from '@/app/(auth)/login/_components/SocialLogin';
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex h-[calc(100vh-60px)] items-center justify-center">
       <div className="flex flex-col">
         <LoginForm />
         <NavigateToSignUp />

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -13,7 +13,7 @@ import { toast } from 'react-toastify';
 import Cookies from 'js-cookie';
 import { z } from 'zod';
 import { useRouter } from 'next/navigation';
-import { signIn } from '@/lib/apis/auth';
+import { signUp } from '@/lib/apis/auth';
 import { InputType } from '@/components/auth/type';
 
 // schema
@@ -144,16 +144,19 @@ export default function SignupForm() {
     if (!isFormValid()) return;
 
     try {
-      const data = await signIn({
+      const data = await signUp({
         body: {
           email: formValues.email,
           password: formValues.password,
+          nickname: formValues.userName,
+          passwordConfirmation: formValues.passwordConfirm,
         },
       });
 
       if (!data) return;
+      console.log(data);
 
-      // 로그인 성공
+      // 회원가입 성공
       const { accessToken, refreshToken, user } = data;
 
       Cookies.set('accessToken', accessToken, {
@@ -174,7 +177,7 @@ export default function SignupForm() {
         sameSite: 'Strict',
       });
 
-      toast.success('로그인 되었습니다.');
+      toast.success('회원가입 되었습니다.');
       router.push('/no-team');
     } catch (error) {
       if (error instanceof Error) {
@@ -184,14 +187,21 @@ export default function SignupForm() {
         if (errorMessage.includes('이메일')) {
           setFormErrors((prev) => ({
             ...prev,
-            email: [errorMessage], // 존재하지 않는 이메일입니다.
+            email: [errorMessage], // 이미 사용중인 이메일입니다.
           }));
-        } else if (errorMessage.includes('비밀번호')) {
+          return;
+        } else if (errorMessage.includes('닉네임')) {
           setFormErrors((prev) => ({
             ...prev,
-            password: [errorMessage], // 비밀번호가 일치하지 않습니다.
+            userName: [errorMessage], // 이미 사용중인 닉네임입니다.
           }));
+          return;
         }
+
+        console.error(error);
+
+        // 그 외
+        toast.error('알 수 없는 오류가 발생했습니다.');
       }
     }
   };

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -8,7 +8,7 @@ import {
   validatePassword,
   validatePasswordConfirm,
 } from '@/utils/inputValidation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import Cookies from 'js-cookie';
 import { z } from 'zod';
@@ -82,7 +82,7 @@ export default function SignupForm() {
 
   const router = useRouter();
 
-  const isFormValid = () => {
+  const isFormValid = useMemo(() => {
     return (
       formValues.email !== '' &&
       formValues.password !== '' &&
@@ -93,7 +93,7 @@ export default function SignupForm() {
       (formErrors.userName?.length ?? 0) === 0 &&
       (formErrors.passwordConfirm?.length ?? 0) === 0
     );
-  };
+  }, [formValues, formErrors]);
 
   const handleInputBlur =
     (key: InputType) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -141,7 +141,7 @@ export default function SignupForm() {
   const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!isFormValid()) return;
+    if (!isFormValid) return;
 
     try {
       const data = await signUp({
@@ -183,7 +183,7 @@ export default function SignupForm() {
       if (error instanceof Error) {
         const errorMessage = error.message;
 
-        // 로그인 실패
+        // 회원가입 실패
         if (errorMessage.includes('이메일')) {
           setFormErrors((prev) => ({
             ...prev,
@@ -200,7 +200,7 @@ export default function SignupForm() {
 
         console.error(error);
 
-        // 그 외
+        // 그 외 오류
         toast.error('알 수 없는 오류가 발생했습니다.');
       }
     }
@@ -258,7 +258,7 @@ export default function SignupForm() {
           styleType="filled"
           radius="sm"
           className="w-[460px] basis-2/3"
-          disabled={!isFormValid()}
+          disabled={!isFormValid}
         >
           회원가입
         </Button>

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -59,17 +59,25 @@ export default function SignupForm() {
   const [formValues, setFormValues] = useState<{
     email: string;
     password: string;
+    userName: string;
+    passwordConfirm: string;
   }>({
     email: '',
     password: '',
+    userName: '',
+    passwordConfirm: '',
   });
 
   const [formErrors, setFormErrors] = useState<{
     email: string[] | undefined;
     password: string[] | undefined;
+    userName: string[] | undefined;
+    passwordConfirm: string[] | undefined;
   }>({
     email: [],
     password: [],
+    userName: [],
+    passwordConfirm: [],
   });
 
   const router = useRouter();
@@ -191,7 +199,7 @@ export default function SignupForm() {
       <div className="mb-10 flex flex-col gap-6">
         <InputWithLabel
           inputType="userName"
-          errorMessage={formErrors.email}
+          errorMessage={formErrors.userName}
           onInputBlur={handleInputBlur}
           onInputChange={handleInputChange}
         />
@@ -209,7 +217,7 @@ export default function SignupForm() {
         />
         <InputWithLabel
           inputType="passwordConfirm"
-          errorMessage={formErrors.password}
+          errorMessage={formErrors.passwordConfirm}
           onInputBlur={handleInputBlur}
           onInputChange={handleInputChange}
         />

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import InputWithLabel from '@/components/auth/InputWithLabel';
+import Button from '@/components/common/Button';
+import {
+  validateEmail,
+  validateName,
+  validatePassword,
+  validatePasswordConfirm,
+} from '@/utils/inputValidation';
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import Cookies from 'js-cookie';
+import { z } from 'zod';
+import { useRouter } from 'next/navigation';
+import { signIn } from '@/lib/apis/auth';
+import { InputType } from '@/components/auth/type';
+
+// schema
+const inputEmptySchema = z.object({
+  email: z.string().nonempty({ message: '이메일은 필수 입력입니다.' }),
+  password: z.string().nonempty({ message: '비밀번호는 필수 입력입니다.' }),
+  userName: z.string().nonempty({ message: '이름은 필수 입력입니다.' }),
+  passwordConfirm: z
+    .string()
+    .nonempty({ message: '비밀번호 확인은 필수 입력입니다.' }),
+});
+
+const inputValidSchema = z
+  .object({
+    email: z.string().refine(validateEmail, {
+      message: '올바른 이메일 형식이 아닙니다.',
+    }),
+    password: z.string().refine(validatePassword, {
+      message:
+        '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.',
+    }),
+    userName: z.string().refine(validateName, {
+      message: '이름은 10자 이하로 입력해주세요.',
+    }),
+    passwordConfirm: z.string(), // 기본 정의
+  })
+
+  // 외부 유효성 검사 함수를 직접 호출해서 사용
+  // ctx : Zod 내부 컨텍스트
+  .superRefine(({ password, passwordConfirm }, ctx) => {
+    const isMatch = validatePasswordConfirm({ password, passwordConfirm });
+
+    if (!isMatch) {
+      ctx.addIssue({
+        path: ['passwordConfirm'],
+        code: z.ZodIssueCode.custom, // 반드시 enum 값이어야 함
+        message: '비밀번호가 일치하지 않습니다.',
+      });
+    }
+  });
+
+export default function SignupForm() {
+  const [formValues, setFormValues] = useState<{
+    email: string;
+    password: string;
+  }>({
+    email: '',
+    password: '',
+  });
+
+  const [formErrors, setFormErrors] = useState<{
+    email: string[] | undefined;
+    password: string[] | undefined;
+  }>({
+    email: [],
+    password: [],
+  });
+
+  const router = useRouter();
+
+  const isFormValid = () => {
+    return (
+      formValues.email !== '' &&
+      formValues.password !== '' &&
+      (formErrors.email?.length ?? 0) === 0 &&
+      (formErrors.password?.length ?? 0) === 0
+    );
+  };
+
+  const handleInputBlur =
+    (key: InputType) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newFormValues = { ...formValues, [key]: e.target.value };
+      setFormValues(newFormValues);
+
+      const result = inputEmptySchema.safeParse(newFormValues);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+
+        setFormErrors((prev) => ({
+          ...prev,
+          [key]: fieldErrors[key],
+        }));
+      } else {
+        setFormErrors((prev) => ({
+          ...prev,
+          [key]: '',
+        }));
+      }
+    };
+
+  const handleInputChange =
+    (key: InputType) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newFormValues = { ...formValues, [key]: e.target.value };
+      const result = inputValidSchema.safeParse(newFormValues);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+
+        setFormErrors((prev) => ({
+          ...prev,
+          [key]: fieldErrors[key],
+        }));
+      } else {
+        setFormErrors((prev) => ({
+          ...prev,
+          [key]: '',
+        }));
+      }
+      setFormValues(newFormValues);
+    };
+
+  const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!isFormValid()) return;
+
+    try {
+      const data = await signIn({
+        body: {
+          email: formValues.email,
+          password: formValues.password,
+        },
+      });
+
+      if (!data) return;
+
+      // 로그인 성공
+      const { accessToken, refreshToken, user } = data;
+
+      Cookies.set('accessToken', accessToken, {
+        path: '/',
+        secure: true,
+        sameSite: 'Strict',
+      });
+
+      Cookies.set('refreshToken', refreshToken, {
+        path: '/',
+        secure: true,
+        sameSite: 'Strict',
+      });
+
+      Cookies.set('userId', user.id.toString(), {
+        path: '/',
+        secure: true,
+        sameSite: 'Strict',
+      });
+
+      toast.success('로그인 되었습니다.');
+      router.push('/no-team');
+    } catch (error) {
+      if (error instanceof Error) {
+        const errorMessage = error.message;
+
+        // 로그인 실패
+        if (errorMessage.includes('이메일')) {
+          setFormErrors((prev) => ({
+            ...prev,
+            email: [errorMessage], // 존재하지 않는 이메일입니다.
+          }));
+        } else if (errorMessage.includes('비밀번호')) {
+          setFormErrors((prev) => ({
+            ...prev,
+            password: [errorMessage], // 비밀번호가 일치하지 않습니다.
+          }));
+        }
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleFormSubmit}>
+      <h1 className="text-4xl-medium mb-10 text-center">회원가입</h1>
+
+      <div className="mb-10 flex flex-col gap-6">
+        <InputWithLabel
+          inputType="userName"
+          errorMessage={formErrors.email}
+          onInputBlur={handleInputBlur}
+          onInputChange={handleInputChange}
+        />
+        <InputWithLabel
+          inputType="email"
+          errorMessage={formErrors.email}
+          onInputBlur={handleInputBlur}
+          onInputChange={handleInputChange}
+        />
+        <InputWithLabel
+          inputType="password"
+          errorMessage={formErrors.password}
+          onInputBlur={handleInputBlur}
+          onInputChange={handleInputChange}
+        />
+        <InputWithLabel
+          inputType="passwordConfirm"
+          errorMessage={formErrors.password}
+          onInputBlur={handleInputBlur}
+          onInputChange={handleInputChange}
+        />
+      </div>
+
+      <div className="flex max-w-[460px] gap-3">
+        <Button
+          size="lg"
+          variant="primary"
+          styleType="filled"
+          radius="sm"
+          className="mb-4 w-[460px] basis-1/3"
+          onClick={() => {
+            router.back();
+          }}
+          disabled={false}
+        >
+          취소
+        </Button>
+
+        <Button
+          size="lg"
+          variant="primary"
+          styleType="filled"
+          radius="sm"
+          className="w-[460px] basis-2/3"
+          disabled={!isFormValid()}
+        >
+          회원가입
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -199,9 +199,12 @@ export default function SignupForm() {
         }
 
         console.error(error);
-
-        // 그 외 오류
-        toast.error('알 수 없는 오류가 발생했습니다.');
+        toast.error(
+          <>
+            문제가 발생했습니다. 잠시 후 다시 시도해주세요.
+            <br />({errorMessage})
+          </>
+        );
       }
     }
   };

--- a/src/app/(auth)/signup/SignupForm.tsx
+++ b/src/app/(auth)/signup/SignupForm.tsx
@@ -86,8 +86,12 @@ export default function SignupForm() {
     return (
       formValues.email !== '' &&
       formValues.password !== '' &&
+      formValues.userName !== '' &&
+      formValues.passwordConfirm !== '' &&
       (formErrors.email?.length ?? 0) === 0 &&
-      (formErrors.password?.length ?? 0) === 0
+      (formErrors.password?.length ?? 0) === 0 &&
+      (formErrors.userName?.length ?? 0) === 0 &&
+      (formErrors.passwordConfirm?.length ?? 0) === 0
     );
   };
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,3 +1,11 @@
+import SignupForm from '@/app/(auth)/signup/SignupForm';
+
 export default function SignupPage() {
-  return <div>SignupPage</div>;
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-col">
+        <SignupForm />
+      </div>
+    </div>
+  );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -2,7 +2,7 @@ import SignupForm from '@/app/(auth)/signup/SignupForm';
 
 export default function SignupPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center">
+    <div className="flex h-[calc(100vh-60px)] items-center justify-center">
       <div className="flex flex-col">
         <SignupForm />
       </div>

--- a/src/components/auth/InputWithLabel.tsx
+++ b/src/components/auth/InputWithLabel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { InputWithLabelProps } from '@/app/(auth)/login/type';
+import { InputWithLabelProps } from '@/components/auth/type';
 import Icons from '@/components/common/Icons';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -17,6 +17,8 @@ export default function InputWithLabel({
   const inputTypeMap: Record<InputWithLabelProps['inputType'], string> = {
     email: '이메일',
     password: '비밀번호',
+    userName: '이름',
+    passwordConfirm: '비밀번호 확인',
   };
 
   const togglePasswordVisibility = () => {
@@ -31,7 +33,7 @@ export default function InputWithLabel({
       <div className="relative">
         <input
           type={
-            inputType === 'password'
+            inputType === 'password' || inputType === 'passwordConfirm'
               ? isPasswordVisible
                 ? 'text'
                 : 'password'
@@ -53,7 +55,7 @@ export default function InputWithLabel({
           {...props}
         />
 
-        {inputType === 'password' && (
+        {(inputType === 'password' || inputType === 'passwordConfirm') && (
           <div className="absolute top-1/2 right-4 -translate-y-1/2">
             {isPasswordVisible ? (
               <Icons.VisibilityOnIcon

--- a/src/components/auth/type.ts
+++ b/src/components/auth/type.ts
@@ -10,4 +10,4 @@ export interface InputWithLabelProps
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export type InputType = 'email' | 'password';
+export type InputType = 'email' | 'password' | 'userName' | 'passwordConfirm';

--- a/src/components/common/Input/InputAuth/index.tsx
+++ b/src/components/common/Input/InputAuth/index.tsx
@@ -6,7 +6,7 @@ import {
   validateName,
   validateEmail,
   validatePassword,
-  validatePasswordMatch,
+  validatePasswordConfirm,
 } from '@/utils/inputValidation';
 import IconRenderer from '@/components/common/Icons/IconRenderer';
 
@@ -50,7 +50,12 @@ const InputAuth = ({
     }
 
     if (pattern === 'passwordMatch') {
-      setIsInvalid(!validatePasswordMatch(originalPassword ?? '', val));
+      setIsInvalid(
+        !validatePasswordConfirm({
+          password: originalPassword ?? '',
+          passwordConfirm: val,
+        })
+      );
     }
   };
 

--- a/src/utils/inputValidation.ts
+++ b/src/utils/inputValidation.ts
@@ -18,9 +18,9 @@ export function validatePassword(value: string, minLength = 8) {
   );
 }
 
-export function validatePasswordMatch(
-  password: string,
-  confirmPassword: string
-) {
-  return password === confirmPassword;
+export function validatePasswordMatch(data: {
+  password: string;
+  passwordConfirm: string;
+}) {
+  return data.password === data.passwordConfirm;
 }

--- a/src/utils/inputValidation.ts
+++ b/src/utils/inputValidation.ts
@@ -18,7 +18,7 @@ export function validatePassword(value: string, minLength = 8) {
   );
 }
 
-export function validatePasswordMatch(data: {
+export function validatePasswordConfirm(data: {
   password: string;
   passwordConfirm: string;
 }) {


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #155

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
- 회원가입 폼 기본 레이아웃 구성
- 취소 버튼 (router.back) 추가 → 로그인 페이지로 이동
- 이메일, 비밀번호, 이름, 비밀번호 확인 필드에 대한 유효성 검사 및 오류 메시지 렌더링
- 회원가입 API 연동 및 오류 메시지 분기 처리 
    - 성공 : 쿠키에 토큰 설정, 토스트 메시지 표시, `/no-team` 으로 라우팅 
    (테스트용, 추후 경로 분기 예정) 
    - 실패 : 서버 응답 기반 오류 메시지 처리 및 네트워크 오류 메시지 명확화
 - `useMemo` 사용으로 폼 유효성 검사 연산 최적화 
 - 로그인, 회원가입 페이지 스크롤바 이슈 해결 
    - `min-h-screen ` > `h-[calc(100vh-60px)]` 로 변경 (헤더 높이 고려)
  - Zod `refine( )` 사용을 위한 `validationPasswordConfirm( )`  인자 구조 변경 (문자열 → 단일 객체)
  - 함수 네이밍 일관성 통일 :  `validationPasswordMatch( )` > `validationPasswordConfirm( )` 
- InputAuth 컴포넌트 빌드 오류 해결
  - InputAuth.tsx : `validationPasswordConfirm` (비밀번호 확인 유효성 확인) 의 인자 수정에 따른 빌드 오류가 있었습니다.
  - InputAuth 는 현재 auth 페이지에서 미사용 중이므로 우선 인자 구조를 객체로 받도록 수정했습니다.
  
<br/>

## 📷 스크린샷
https://github.com/user-attachments/assets/9ead4173-b61d-44bd-8b56-a33d6068cd57

<br/>

## 📢 공유 사항
<!--- 리뷰어가 알면 좋을 내용이나, 차후 작업 시 참고할 메모를 작성합니다. -->
- 회원가입 페이지에 취소 버튼을 추가했습니다 (뒤로 가기)
- Zod `refine( )` 대응을 위해 `validationPasswordConfirm( )` 함수 인자로 단일 객체를 받도록 수정되었습니다. 
이후 수정된 `InputAuth.tsx` 도 이에 따른 변경 사항입니다. 
- **이전 PR 에서 논의된 `onBlur` 이슈** ([#152 코멘트](https://github.com/FE13-Part4-Team2/Coworkers/pull/152#issuecomment-2868323879)) 는 전체 Auth 페이지 구현 후 작업할 예정입니다
  - issue 탭에 등록해두었습니다. 
  - 현재 분기된 Zod 스키마를 통합하여 개선할 계획입니다.
- **공통 AuthLayout 적용 등 리팩토링**은  전체 Auth 페이지 구현 후 진행될 예정입니다.  리뷰 시 참고 부탁드립니다 !
```ts
// 네트워크 에러 발생
        toast.error(
          <>
            문제가 발생했습니다. 잠시 후 다시 시도해주세요.
            <br />({errorMessage})
          </>
        );
```

<br/>

## 📚 참고 자료
<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가합니다. -->
- [Zod refine()](https://zod.dev/?id=refine)