### PR TITLE
[feat, design] #164 ResetPasswordPage, ResetPasswordForm: 비밀번호 재설정 폼 레이아웃 / 입력 유효성 구현

### DIFF
--- a/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import InputWithLabel from '@/components/auth/InputWithLabel';
+import Button from '@/components/common/Button';
+import { useState } from 'react';
+
+export default function ResetPasswordForm() {
+  const [formErrors, setFormErrors] = useState<{
+    email: string[] | undefined;
+    password: string[] | undefined;
+  }>({
+    email: [],
+    password: [],
+  });
+
+  const handleFormSubmit = () => {
+    console.log('form submit');
+    setFormErrors({
+      email: [],
+      password: [],
+    });
+  };
+  return (
+    <form onSubmit={handleFormSubmit}>
+      <h1 className="text-4xl-medium mb-20 text-center">비밀번호 재설정</h1>
+
+      <div className="mb-10 flex flex-col gap-6">
+        <InputWithLabel
+          inputType="password"
+          errorMessage={formErrors.email}
+          mode="resetPasswordPage"
+        />
+        <InputWithLabel
+          inputType="passwordConfirm"
+          errorMessage={formErrors.password}
+          mode="resetPasswordPage"
+        />
+      </div>
+
+      <Button
+        size="lg"
+        variant="primary"
+        styleType="filled"
+        radius="sm"
+        className="w-[460px]"
+        disabled={false}
+      >
+        재설정
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -2,22 +2,76 @@
 
 import InputWithLabel from '@/components/auth/InputWithLabel';
 import Button from '@/components/common/Button';
-import { useState } from 'react';
+import { validatePassword } from '@/utils/inputValidation';
+import { useMemo, useState } from 'react';
+import { z } from 'zod';
+
+// schema
+const resetPasswordSchema = z.object({
+  password: z
+    .string()
+    .nonempty({ message: '비밀번호는 필수 입력입니다.' })
+    .refine(validatePassword, {
+      message:
+        '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.',
+    }),
+  passwordConfirm: z
+    .string()
+    .nonempty({ message: '비밀번호 확인은 필수 입력입니다.' }),
+});
 
 export default function ResetPasswordForm() {
-  const [formErrors, setFormErrors] = useState<{
-    email: string[] | undefined;
-    password: string[] | undefined;
+  const [formValues, setFormValues] = useState<{
+    password: string;
+    passwordConfirm: string;
   }>({
-    email: [],
-    password: [],
+    password: '',
+    passwordConfirm: '',
   });
+  const [formErrors, setFormErrors] = useState<{
+    password: string[] | undefined;
+    passwordConfirm: string[] | undefined;
+  }>({
+    password: [],
+    passwordConfirm: [],
+  });
+
+  const isFormValid = useMemo(() => {
+    return (
+      formValues.password !== '' &&
+      formValues.passwordConfirm !== '' &&
+      (formErrors.password?.length ?? 0) === 0 &&
+      (formErrors.passwordConfirm?.length ?? 0) === 0
+    );
+  }, [formValues, formErrors]);
+
+  const handleInputChange =
+    (key: 'password' | 'passwordConfirm') =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newFormValues = { ...formValues, [key]: e.target.value };
+      const result = resetPasswordSchema.safeParse(newFormValues);
+
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+
+        setFormErrors((prev) => ({
+          ...prev,
+          [key]: fieldErrors[key],
+        }));
+      } else {
+        setFormErrors((prev) => ({
+          ...prev,
+          [key]: '',
+        }));
+      }
+      setFormValues(newFormValues);
+    };
 
   const handleFormSubmit = () => {
     console.log('form submit');
     setFormErrors({
-      email: [],
       password: [],
+      passwordConfirm: [],
     });
   };
   return (
@@ -27,13 +81,15 @@ export default function ResetPasswordForm() {
       <div className="mb-10 flex flex-col gap-6">
         <InputWithLabel
           inputType="password"
-          errorMessage={formErrors.email}
+          errorMessage={formErrors.password}
           mode="resetPasswordPage"
+          onChange={handleInputChange('password')}
         />
         <InputWithLabel
           inputType="passwordConfirm"
-          errorMessage={formErrors.password}
+          errorMessage={formErrors.passwordConfirm}
           mode="resetPasswordPage"
+          onChange={handleInputChange('passwordConfirm')}
         />
       </div>
 
@@ -43,7 +99,7 @@ export default function ResetPasswordForm() {
         styleType="filled"
         radius="sm"
         className="w-[460px]"
-        disabled={false}
+        disabled={!isFormValid}
       >
         재설정
       </Button>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,9 +1,8 @@
-import ResetPasswordForm from "@/app/(auth)/reset-password/ResetPasswordForm";
-
+import ResetPasswordForm from '@/app/(auth)/reset-password/ResetPasswordForm';
 
 export default function ResetPasswordPage() {
   return (
-    <div className="flex h-[calc(100vh-60px)] items-center justify-center">
+    <div className="mt-[140px] flex h-[calc(100vh-60px)] justify-center">
       <div className="flex flex-col">
         <ResetPasswordForm />
       </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -2,7 +2,7 @@ import ResetPasswordForm from '@/app/(auth)/reset-password/ResetPasswordForm';
 
 export default function ResetPasswordPage() {
   return (
-    <div className="flex h-[calc(100vh-80px)] justify-center pt-[140px]">
+    <div className="flex h-[calc(100vh-60px)] justify-center pt-[140px]">
       <div className="flex flex-col">
         <ResetPasswordForm />
       </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -2,7 +2,7 @@ import ResetPasswordForm from '@/app/(auth)/reset-password/ResetPasswordForm';
 
 export default function ResetPasswordPage() {
   return (
-    <div className="mt-[140px] flex h-[calc(100vh-60px)] justify-center">
+    <div className="flex h-[calc(100vh-80px)] justify-center pt-[140px]">
       <div className="flex flex-col">
         <ResetPasswordForm />
       </div>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,3 +1,12 @@
+import ResetPasswordForm from "@/app/(auth)/reset-password/ResetPasswordForm";
+
+
 export default function ResetPasswordPage() {
-  return <div>ResetPasswordPage</div>;
+  return (
+    <div className="flex h-[calc(100vh-60px)] items-center justify-center">
+      <div className="flex flex-col">
+        <ResetPasswordForm />
+      </div>
+    </div>
+  );
 }

--- a/src/components/auth/InputWithLabel.tsx
+++ b/src/components/auth/InputWithLabel.tsx
@@ -10,6 +10,7 @@ export default function InputWithLabel({
   errorMessage = [],
   onInputBlur,
   onInputChange,
+  mode,
   ...props
 }: InputWithLabelProps) {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -42,7 +43,11 @@ export default function InputWithLabel({
           id={inputType}
           name={inputType}
           required
-          placeholder={`${inputTypeMap[inputType]}을 입력해주세요.`}
+          placeholder={
+            mode === 'resetPasswordPage'
+              ? '비밀번호 재설정 페이지'
+              : `${inputTypeMap[inputType]}을 입력해주세요.`
+          }
           autoComplete="true"
           className={clsx(
             'w-full rounded-xl border bg-slate-800 p-4 outline-hidden',

--- a/src/components/auth/InputWithLabel.tsx
+++ b/src/components/auth/InputWithLabel.tsx
@@ -22,6 +22,8 @@ export default function InputWithLabel({
     passwordConfirm: '비밀번호 확인',
   };
 
+  const isPasswordResetPage = mode === 'resetPasswordPage';
+
   const togglePasswordVisibility = () => {
     setIsPasswordVisible((prev) => !prev);
   };
@@ -44,9 +46,11 @@ export default function InputWithLabel({
           name={inputType}
           required
           placeholder={
-            mode === 'resetPasswordPage'
-              ? '비밀번호 재설정 페이지'
-              : `${inputTypeMap[inputType]}을 입력해주세요.`
+            isPasswordResetPage && inputType === 'password'
+              ? '비밀번호 (영문, 숫자 포함 8자 이상) 를 입력해주세요.'
+              : isPasswordResetPage && inputType === 'passwordConfirm'
+                ? '새 비밀번호를 다시 한번 입력해주세요.'
+                : `${inputTypeMap[inputType]}을 입력해주세요.`
           }
           autoComplete="true"
           className={clsx(

--- a/src/components/auth/InputWithLabel.tsx
+++ b/src/components/auth/InputWithLabel.tsx
@@ -47,7 +47,7 @@ export default function InputWithLabel({
           required
           placeholder={
             isPasswordResetPage && inputType === 'password'
-              ? '비밀번호 (영문, 숫자 포함 8자 이상) 를 입력해주세요.'
+              ? '영문과 숫자를 포함한 8자 이상의 비밀번호를 입력해주세요.'
               : isPasswordResetPage && inputType === 'passwordConfirm'
                 ? '새 비밀번호를 다시 한번 입력해주세요.'
                 : `${inputTypeMap[inputType]}을 입력해주세요.`

--- a/src/components/auth/type.ts
+++ b/src/components/auth/type.ts
@@ -1,11 +1,12 @@
 export interface InputWithLabelProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   inputType: InputType;
-  errorMessage: string[] | undefined;
-  onInputBlur: (
+  errorMessage?: string[] | undefined;
+  mode?: 'resetPasswordPage' | undefined;
+  onInputBlur?: (
     key: InputType
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onInputChange: (
+  onInputChange?: (
     key: InputType
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
 }


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #164 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
- 비밀번호 재설정 폼 레이아웃 구성
- `InputWithLabel` 컴포넌트 활용, 새 비밀번호 및 확인 입력 필드 추가
- 비밀번호 보기 / 숨기기 토글 기능 적용
- 입력 필드 placeholder 반영 
  - 비어 있는 경우 : `비밀번호/비밀번호 확인은 필수 입력입니다.`
  - 유효하지 않은 경우
     - 비밀번호 : `비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.`
     - 비밀번호 확인 : `비밀번호가 일치하지 않습니다.`
- 세로 스크롤바 이슈 해결 :`mt-[140px]` -> `pt-[140px]` 수정
<br/>

## 📷 스크린샷

https://github.com/user-attachments/assets/9b9a5fbc-c918-4357-9de8-b835ff9b67a4

<img src = "https://github.com/user-attachments/assets/efcbf3b2-055f-4088-ab7f-b7ec3576322c" width = "500"/>
<img src = "https://github.com/user-attachments/assets/1192f29b-68ad-4b1c-be53-d17992c1c7e4" width = "500" />

- 영상에는 보더 스타일이 일부만 적용되는 것처럼 보여서 실제 화면도 함께 첨부합니다 😅 (정상적으로 동작) 

<!--- 없을 시 해당 목차는 삭제합니다. -->

<br/>

## 📢 공유 사항
<!--- 리뷰어가 알면 좋을 내용이나, 차후 작업 시 참고할 메모를 작성합니다. -->
- `superRefine` 을 사용해 스키마를 하나로 통합하고, 이벤트는 onChange 로 통일했습니다. 
- 비밀번호 재설정 링크 클릭 후 리다이렉트 되는 `/reset-password` 페이지 먼저 구현했습니다.
- 전체적인 로직과 비밀번호 재설정 API 요청은 다음 작업에서 진행할 예정입니다

<br/>

## 📚 참고 자료
<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가합니다. -->
- [Zod superRefine](https://zod.dev/?id=superrefine)