### PR TITLE
[feat, refactor] #137 team: 멤버 삭제 기능 추가 & 아이템 개수 변경 시 페이지네이션 즉시 반영 처리

### DIFF
--- a/src/app/(team)/team/[teamid]/page.tsx
+++ b/src/app/(team)/team/[teamid]/page.tsx
@@ -69,7 +69,7 @@ export default async function TeamPage({
       </div>
       <MemberList
         items={membersData}
-        group={groupData}
+        groupId={groupId}
         userId={Number(userId)}
       />
     </div>

--- a/src/app/(team)/team/[teamid]/page.tsx
+++ b/src/app/(team)/team/[teamid]/page.tsx
@@ -18,7 +18,7 @@ export default async function TeamPage({
   const userId = cookies().get('userId')?.value;
   const groupId = Number(params.teamid);
 
-  const groupData = await getGroupById({ groupId });
+  const groupData = await getGroupById({ groupId, tag: ['group'] });
   const membersData = groupData?.members ?? [];
   const taskListsData = groupData?.taskLists ?? [];
 
@@ -68,8 +68,8 @@ export default async function TeamPage({
         <AddButton variant="member" groupId={groupId} />
       </div>
       <MemberList
+        group={groupData}
         items={membersData}
-        groupId={groupId}
         userId={Number(userId)}
       />
     </div>

--- a/src/app/(team)/team/_components/AddButton/index.tsx
+++ b/src/app/(team)/team/_components/AddButton/index.tsx
@@ -53,7 +53,7 @@ const AddButton = ({ variant, groupId }: AddButtonProps) => {
       onClick={
         variant === 'tasklist' ? openCreateTaskListModal : openInviteMemberModal
       }
-      className="text-md-regular text-green-700"
+      className="text-md-regular text-green-700 hover:text-green-600"
     >
       {ADD_BUTTON_TEXT[variant]}
     </button>

--- a/src/app/(team)/team/_components/MemberList/MemberCard.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberCard.tsx
@@ -4,7 +4,7 @@ import MemberMenu from '@/app/(team)/team/_components/MemberList/MemberMenu';
 import MemberProfileModal from '@/components/common/Modal/content/MemberProfileModal';
 import { useModalStore } from '@/store/useModalStore';
 import { useIsAdmin } from '@/hooks/useIsAdmin';
-import { GroupMemberResponse } from '@/lib/apis/group/type';
+import { GroupResponse } from '@/lib/apis/group/type';
 import {
   memberCardContainerStyle,
   memberCardItemWrapperStyle,
@@ -14,17 +14,17 @@ import { toast } from 'react-toastify';
 import { TOAST_MESSAGES } from '@/constants/messages';
 
 interface MemberCardProps {
-  members: GroupMemberResponse[];
+  group: GroupResponse;
   name: string;
   email: string;
   memberId: number;
   userId: number;
   profileImage: string | null;
-  onDelete: (memberId: number, name: string) => void;
+  onDelete: (memberId: number) => void;
 }
 
 const MemberCard = ({
-  members,
+  group,
   name,
   email,
   memberId,
@@ -32,7 +32,7 @@ const MemberCard = ({
   profileImage,
   onDelete,
 }: MemberCardProps) => {
-  const isAdmin = useIsAdmin({ membersData: members, userId });
+  const isAdmin = useIsAdmin({ membersData: group.members, userId });
 
   const { openModal } = useModalStore();
   const openMemberProfileModal = () => {
@@ -87,12 +87,7 @@ const MemberCard = ({
 
         {/* 메뉴 버튼 */}
         {isAdmin && userId !== memberId && (
-          <MemberMenu
-            members={members}
-            memberId={memberId}
-            name={name}
-            onDelete={onDelete}
-          />
+          <MemberMenu memberId={memberId} name={name} onDelete={onDelete} />
         )}
       </div>
     </div>

--- a/src/app/(team)/team/_components/MemberList/MemberCard.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberCard.tsx
@@ -3,8 +3,8 @@ import BreakEmail from '@/app/(team)/team/_components/MemberList/BreakEmail';
 import MemberMenu from '@/app/(team)/team/_components/MemberList/MemberMenu';
 import MemberProfileModal from '@/components/common/Modal/content/MemberProfileModal';
 import { useModalStore } from '@/store/useModalStore';
-import { GroupResponse } from '@/lib/apis/group/type';
 import { useIsAdmin } from '@/hooks/useIsAdmin';
+import { GroupMemberResponse } from '@/lib/apis/group/type';
 import {
   memberCardContainerStyle,
   memberCardItemWrapperStyle,
@@ -14,7 +14,8 @@ import { toast } from 'react-toastify';
 import { TOAST_MESSAGES } from '@/constants/messages';
 
 interface MemberCardProps {
-  group: GroupResponse;
+  groupId: number;
+  members: GroupMemberResponse[];
   name: string;
   email: string;
   memberId: number;
@@ -23,14 +24,15 @@ interface MemberCardProps {
 }
 
 const MemberCard = ({
-  group,
+  groupId,
+  members,
   name,
   email,
   memberId,
   userId,
   profileImage,
 }: MemberCardProps) => {
-  const isAdmin = useIsAdmin({ membersData: group.members, userId });
+  const isAdmin = useIsAdmin({ membersData: members, userId });
 
   const { openModal } = useModalStore();
   const openMemberProfileModal = () => {
@@ -85,7 +87,12 @@ const MemberCard = ({
 
         {/* 메뉴 버튼 */}
         {isAdmin && userId !== memberId && (
-          <MemberMenu groupId={group.id} memberId={memberId} name={name} />
+          <MemberMenu
+            groupId={groupId}
+            members={members}
+            memberId={memberId}
+            name={name}
+          />
         )}
       </div>
     </div>

--- a/src/app/(team)/team/_components/MemberList/MemberCard.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberCard.tsx
@@ -84,7 +84,9 @@ const MemberCard = ({
         </div>
 
         {/* 메뉴 버튼 */}
-        {isAdmin && userId !== memberId && <MemberMenu />}
+        {isAdmin && userId !== memberId && (
+          <MemberMenu groupId={group.id} memberId={memberId} name={name} />
+        )}
       </div>
     </div>
   );

--- a/src/app/(team)/team/_components/MemberList/MemberCard.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberCard.tsx
@@ -17,16 +17,18 @@ interface MemberCardProps {
   group: GroupResponse;
   name: string;
   email: string;
+  memberId: number;
   userId: number;
-  userImage: string | null;
+  profileImage: string | null;
 }
 
 const MemberCard = ({
   group,
   name,
   email,
+  memberId,
   userId,
-  userImage,
+  profileImage,
 }: MemberCardProps) => {
   const isAdmin = useIsAdmin({ membersData: group.members, userId });
 
@@ -50,7 +52,7 @@ const MemberCard = ({
           },
         },
       },
-      <MemberProfileModal image={userImage} name={name} email={email} />
+      <MemberProfileModal image={profileImage} name={name} email={email} />
     );
   };
 
@@ -69,7 +71,7 @@ const MemberCard = ({
         <div className="tablet:h-[33px] tablet:w-[146px] flex items-center gap-3">
           {/* 프로필 아이콘 */}
           <UserIcon
-            image={userImage}
+            image={profileImage}
             sizeClass="tablet:size-8 size-6"
             imageSize="32px"
           />
@@ -82,7 +84,7 @@ const MemberCard = ({
         </div>
 
         {/* 메뉴 버튼 */}
-        {isAdmin && <MemberMenu />}
+        {isAdmin && userId !== memberId && <MemberMenu />}
       </div>
     </div>
   );

--- a/src/app/(team)/team/_components/MemberList/MemberCard.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberCard.tsx
@@ -14,23 +14,23 @@ import { toast } from 'react-toastify';
 import { TOAST_MESSAGES } from '@/constants/messages';
 
 interface MemberCardProps {
-  groupId: number;
   members: GroupMemberResponse[];
   name: string;
   email: string;
   memberId: number;
   userId: number;
   profileImage: string | null;
+  onDelete: (memberId: number, name: string) => void;
 }
 
 const MemberCard = ({
-  groupId,
   members,
   name,
   email,
   memberId,
   userId,
   profileImage,
+  onDelete,
 }: MemberCardProps) => {
   const isAdmin = useIsAdmin({ membersData: members, userId });
 
@@ -88,10 +88,10 @@ const MemberCard = ({
         {/* 메뉴 버튼 */}
         {isAdmin && userId !== memberId && (
           <MemberMenu
-            groupId={groupId}
             members={members}
             memberId={memberId}
             name={name}
+            onDelete={onDelete}
           />
         )}
       </div>

--- a/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
@@ -1,14 +1,51 @@
 import TaskMenuButton from '@/components/task/TaskMenu/TaskMenuButton';
 import DropDown from '@/components/common/Dropdown';
+import { useModalStore } from '@/store/useModalStore';
+import { deleteGroupMemberById } from '@/lib/apis/group';
+import { toast } from 'react-toastify';
 
-const MemberMenu = () => {
+interface MemberMenuProps {
+  groupId: number;
+  memberId: number;
+  name: string;
+}
+
+const MemberMenu = ({ groupId, memberId, name }: MemberMenuProps) => {
+  const { openModal } = useModalStore();
+
+  const handleMemberDelete = async () => {
+    try {
+      await deleteGroupMemberById({ groupId, memberId });
+
+      toast.success(`'${name}'님을 내보냈습니다.`);
+    } catch (error) {
+      console.log('멤버 삭제 실패', error);
+      toast.error('멤버 내보내기에 실패했습니다.');
+    }
+  };
+
+  const openMemberDeleteModal = () => {
+    openModal({
+      variant: 'danger',
+      title: `'${name}' 님을 팀에서 내보내시겠어요?`,
+      button: {
+        number: 2,
+        text: '확인',
+        onRequest: handleMemberDelete,
+      },
+    });
+  };
+
   return (
     <DropDown>
       <DropDown.Trigger className="mb-0">
         <TaskMenuButton size="sm" />
       </DropDown.Trigger>
       <DropDown.Menu align="right" className="mt-2 h-[40px] w-[120px]">
-        <DropDown.Item className="text-md-regular h-[38px] w-full">
+        <DropDown.Item
+          onClick={openMemberDeleteModal}
+          className="text-md-regular h-[38px] w-full"
+        >
           내보내기
         </DropDown.Item>
       </DropDown.Menu>

--- a/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
@@ -1,30 +1,17 @@
 import TaskMenuButton from '@/components/task/TaskMenu/TaskMenuButton';
 import DropDown from '@/components/common/Dropdown';
-import { useQueryClient } from '@tanstack/react-query';
 import { useModalStore } from '@/store/useModalStore';
 import { GroupMemberResponse } from '@/lib/apis/group/type';
-import { deleteGroupMemberById } from '@/lib/apis/group';
-import { toast } from 'react-toastify';
 
 interface MemberMenuProps {
-  groupId: number;
   members: GroupMemberResponse[];
   memberId: number;
   name: string;
+  onDelete: (memberId: number, name: string) => void;
 }
 
-const MemberMenu = ({ groupId, members, memberId, name }: MemberMenuProps) => {
+const MemberMenu = ({ memberId, name, onDelete }: MemberMenuProps) => {
   const { openModal } = useModalStore();
-
-  const handleMemberDelete = async () => {
-    try {
-      await deleteGroupMemberById({ groupId, memberId });
-      toast.success(`'${name}'님을 내보냈습니다.`);
-    } catch (error) {
-      console.log('멤버 삭제 실패', error);
-      toast.error('멤버 내보내기에 실패했습니다.');
-    }
-  };
 
   const openMemberDeleteModal = () => {
     openModal({
@@ -33,7 +20,7 @@ const MemberMenu = ({ groupId, members, memberId, name }: MemberMenuProps) => {
       button: {
         number: 2,
         text: '확인',
-        onRequest: handleMemberDelete,
+        onRequest: () => onDelete(memberId, name),
       },
     });
   };

--- a/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
@@ -1,13 +1,11 @@
 import TaskMenuButton from '@/components/task/TaskMenu/TaskMenuButton';
 import DropDown from '@/components/common/Dropdown';
 import { useModalStore } from '@/store/useModalStore';
-import { GroupMemberResponse } from '@/lib/apis/group/type';
 
 interface MemberMenuProps {
-  members: GroupMemberResponse[];
   memberId: number;
   name: string;
-  onDelete: (memberId: number, name: string) => void;
+  onDelete: (memberId: number) => void;
 }
 
 const MemberMenu = ({ memberId, name, onDelete }: MemberMenuProps) => {
@@ -20,7 +18,7 @@ const MemberMenu = ({ memberId, name, onDelete }: MemberMenuProps) => {
       button: {
         number: 2,
         text: '확인',
-        onRequest: () => onDelete(memberId, name),
+        onRequest: () => onDelete(memberId),
       },
     });
   };

--- a/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
+++ b/src/app/(team)/team/_components/MemberList/MemberMenu.tsx
@@ -1,22 +1,24 @@
 import TaskMenuButton from '@/components/task/TaskMenu/TaskMenuButton';
 import DropDown from '@/components/common/Dropdown';
+import { useQueryClient } from '@tanstack/react-query';
 import { useModalStore } from '@/store/useModalStore';
+import { GroupMemberResponse } from '@/lib/apis/group/type';
 import { deleteGroupMemberById } from '@/lib/apis/group';
 import { toast } from 'react-toastify';
 
 interface MemberMenuProps {
   groupId: number;
+  members: GroupMemberResponse[];
   memberId: number;
   name: string;
 }
 
-const MemberMenu = ({ groupId, memberId, name }: MemberMenuProps) => {
+const MemberMenu = ({ groupId, members, memberId, name }: MemberMenuProps) => {
   const { openModal } = useModalStore();
 
   const handleMemberDelete = async () => {
     try {
       await deleteGroupMemberById({ groupId, memberId });
-
       toast.success(`'${name}'님을 내보냈습니다.`);
     } catch (error) {
       console.log('멤버 삭제 실패', error);

--- a/src/app/(team)/team/_components/MemberList/index.tsx
+++ b/src/app/(team)/team/_components/MemberList/index.tsx
@@ -26,7 +26,7 @@ const MemberList = ({ group, items, userId }: MemberListProps) => {
 
   const handleMemberDelete = async (memberId: number) => {
     try {
-      await deleteGroupMemberById({ groupId, memberId });
+      await deleteGroupMemberById({ groupId, memberId, tag: ['group'] });
       setMemberList(
         (prev) => prev.filter((items) => items.userId !== memberId) // delete 함수에 전달하지 않은 id만 남김
       );

--- a/src/app/(team)/team/_components/MemberList/index.tsx
+++ b/src/app/(team)/team/_components/MemberList/index.tsx
@@ -24,6 +24,11 @@ const MemberList = ({ group, items, userId }: MemberListProps) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(6);
 
+  const totalPage = Math.ceil(memberList.length / perPage);
+  const startIndex = (page - 1) * perPage;
+  const endIndex = startIndex + perPage;
+  const currentItems = memberList.slice(startIndex, endIndex);
+
   const handleMemberDelete = async (memberId: number) => {
     try {
       await deleteGroupMemberById({ groupId, memberId, tag: ['group'] });
@@ -37,6 +42,7 @@ const MemberList = ({ group, items, userId }: MemberListProps) => {
     }
   };
 
+  // MOBILE: MemberCard 4개씩 표시
   useEffect(() => {
     const handleResize = () => {
       setPerPage(window.innerWidth >= 744 ? 6 : 4);
@@ -47,10 +53,13 @@ const MemberList = ({ group, items, userId }: MemberListProps) => {
     return () => window.addEventListener('resize', handleResize);
   }, []);
 
-  const totalPage = Math.ceil(items.length / perPage);
-  const startIndex = (page - 1) * perPage;
-  const endIndex = startIndex + perPage;
-  const currentItems = memberList.slice(startIndex, endIndex);
+  // 멤버 수 변경 발생 시 페이지 즉시 반영
+  useEffect(() => {
+    const newTotalPage = Math.ceil(memberList.length / perPage);
+    if (page > newTotalPage) {
+      setPage(newTotalPage);
+    }
+  }, [memberList.length, perPage]);
 
   const handlePrev = () => {
     if (page > 1) setPage((prev) => prev - 1);
@@ -67,7 +76,7 @@ const MemberList = ({ group, items, userId }: MemberListProps) => {
           <MemberCard
             key={item.userId}
             {...item}
-            members={items}
+            group={group}
             name={item.userName}
             email={item.userEmail}
             memberId={item.userId}

--- a/src/app/(team)/team/_components/MemberList/index.tsx
+++ b/src/app/(team)/team/_components/MemberList/index.tsx
@@ -2,7 +2,7 @@
 import MemberCard from '@/app/(team)/team/_components/MemberList/MemberCard';
 import Pagination from '@/app/(team)/team/_components/TaskListBarList/Pagination';
 import { useState, useEffect } from 'react';
-import { GroupResponse, GroupMemberResponse } from '@/lib/apis/group/type';
+import { GroupMemberResponse } from '@/lib/apis/group/type';
 import {
   memberListContainerStyle,
   memberListWrapperStyle,
@@ -10,11 +10,11 @@ import {
 
 interface MemberListProps {
   items: GroupMemberResponse[];
-  group: GroupResponse;
+  groupId: number;
   userId: number;
 }
 
-const MemberList = ({ items, group, userId }: MemberListProps) => {
+const MemberList = ({ items, groupId, userId }: MemberListProps) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(6);
 
@@ -48,9 +48,10 @@ const MemberList = ({ items, group, userId }: MemberListProps) => {
           <MemberCard
             key={item.userId}
             {...item}
-            group={group}
+            members={items}
             name={item.userName}
             email={item.userEmail}
+            groupId={groupId}
             memberId={item.userId}
             userId={Number(userId)}
             profileImage={item.userImage}

--- a/src/app/(team)/team/_components/MemberList/index.tsx
+++ b/src/app/(team)/team/_components/MemberList/index.tsx
@@ -51,8 +51,9 @@ const MemberList = ({ items, group, userId }: MemberListProps) => {
             group={group}
             name={item.userName}
             email={item.userEmail}
+            memberId={item.userId}
             userId={Number(userId)}
-            userImage={item.userImage}
+            profileImage={item.userImage}
           />
         ))}
       </div>

--- a/src/app/(team)/team/_components/MemberList/index.tsx
+++ b/src/app/(team)/team/_components/MemberList/index.tsx
@@ -53,7 +53,7 @@ const MemberList = ({ group, items, userId }: MemberListProps) => {
     return () => window.addEventListener('resize', handleResize);
   }, []);
 
-  // 멤버 수 변경 발생 시 페이지 즉시 반영
+  // 멤버 수 변경 시 페이지 즉시 반영
   useEffect(() => {
     const newTotalPage = Math.ceil(memberList.length / perPage);
     if (page > newTotalPage) {

--- a/src/app/(team)/team/_components/ReportBanner/index.tsx
+++ b/src/app/(team)/team/_components/ReportBanner/index.tsx
@@ -16,19 +16,19 @@ interface ReportBannerProps {
 const ReportBanner = ({ progress, total, done }: ReportBannerProps) => {
   return (
     <div className={`${reportBannerContainerStyle}`}>
-      {/* 아이템 래퍼 */}
       <div className={`${reportBannerItemWrapperStyle}`}>
-        {/* 진행률 래퍼 */}
         <div className="flex items-center justify-center gap-10">
           {/* 임시 원형 아이콘 */}
           <div className="tablet:h-[140px] tablet:w-[140px] tablet:border-[30px] relative h-[120px] w-[120px] rounded-full border-[24px] border-green-700" />
-          {/* 진행률 텍스트 */}
+          {/* progress text wrapper */}
           <div className="tablet:relative absolute flex flex-col gap-1">
+            {/* TABLET 이상 */}
             <p className="tablet:block text-md-medium hidden">
               오늘의
               <br />
               진행 상황
             </p>
+            {/* MOBILE */}
             <p className="tablet:hidden text-md-medium block text-center">
               오늘
             </p>
@@ -36,7 +36,7 @@ const ReportBanner = ({ progress, total, done }: ReportBannerProps) => {
           </div>
         </div>
 
-        {/* Todo & Done Card */}
+        {/* todo & done Card */}
         <div className={`${reportCardsWrapperStyle}`}>
           <ReportCard variant="todo" value={total - done} />
           <ReportCard variant="done" value={done} />

--- a/src/app/(team)/team/_components/TaskListBarList/ProgressBadge.tsx
+++ b/src/app/(team)/team/_components/TaskListBarList/ProgressBadge.tsx
@@ -17,7 +17,7 @@ const ProgressBadge = ({ total, done }: ProgressBadgeProps) => {
   return (
     <div className={`${progressBadgeContainerStyle}`}>
       {isDone ? (
-        <IconRenderer name="DoneIcon" size={14} className="text-green-700" />
+        <IconRenderer name="ProgressDoneIcon" size={16} />
       ) : (
         <CircularProgress percentage={percentage} />
       )}

--- a/src/app/(team)/team/_components/TaskListBarList/index.tsx
+++ b/src/app/(team)/team/_components/TaskListBarList/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 import TaskListBar from '@/app/(team)/team/_components/TaskListBarList/TaskListBar';
 import Pagination from '@/app/(team)/team/_components/TaskListBarList/Pagination';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { TaskListResponse } from '@/lib/apis/taskList/type';
 import { GroupMemberResponse } from '@/lib/apis/group/type';
 import { calculateTaskListProgress } from '@/utils/calculateTaskListProgress';
@@ -28,6 +28,14 @@ const TaskListBarList = ({
   const startIndex = (page - 1) * PER_PAGE;
   const endIndex = startIndex + PER_PAGE;
   const currentItems = items.slice(startIndex, endIndex);
+
+  // 할 일 목록 개수 변경 시 페이지 즉시 반영
+  useEffect(() => {
+    const newTotalPage = Math.ceil(items.length / PER_PAGE);
+    if (page > newTotalPage) {
+      setPage(newTotalPage);
+    }
+  }, [items.length, PER_PAGE]);
 
   const handlePrev = () => {
     if (page > 1) setPage((prev) => prev - 1);

--- a/src/app/(team)/team/_components/TaskListBarList/styles.ts
+++ b/src/app/(team)/team/_components/TaskListBarList/styles.ts
@@ -42,7 +42,7 @@ export const colorChipStyle = clsx(
 
 // 📌ProgressBadge.tsx style
 export const progressBadgeContainerStyle = clsx(
-  'flex items-center justify-center shrink-0 gap-1.5',
+  'flex items-center justify-center shrink-0 gap-1',
   'h-[25px] min-w-[58px]',
   'bg-slate-900',
   RADIUS

--- a/src/components/common/Modal/content/MemberProfileModal/index.tsx
+++ b/src/components/common/Modal/content/MemberProfileModal/index.tsx
@@ -13,7 +13,6 @@ export default function MemberProfileModal({
 }: MemberProfileModalProps) {
   return (
     <div className="flex flex-col items-center justify-center gap-6 text-center">
-      {' '}
       <UserIcon
         image={image}
         sizeClass="tablet:size-[52px] size-[46px]"

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -5,4 +5,8 @@ export const TOAST_MESSAGES = {
     copyEmailSuccess: '이메일이 복사되었습니다.',
     copyEmailFail: '이메일 복사에 실패했습니다.',
   },
+  member: {
+    deleteSuccess: '멤버를 내보냈습니다.',
+    deleteFail: '멤버 내보내기에 실패했습니다.',
+  },
 };

--- a/src/lib/apis/group/index.ts
+++ b/src/lib/apis/group/index.ts
@@ -91,13 +91,16 @@ export async function getGroupMemberById({
 export async function deleteGroupMemberById({
   groupId,
   memberId,
+  tag,
 }: {
   groupId: number;
   memberId: number;
+  tag?: string[];
 }): Promise<null> {
-  return clientFetcher<undefined, null>({
+  return serverFetcher<undefined, null>({
     url: `/groups/${groupId}/member/${memberId}`,
     method: 'DELETE',
+    tag,
   });
 }
 


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
#137 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
### MemberList
- MemberCard: 관리자 본인 카드에는 메뉴 버튼 표시 x
- 멤버 내보내기(삭제) 기능 추가
- 멤버 수 변경 시 페이지네이션 즉시 반영되도록 변경

### TaskListBarList
- 할 일 목록 개수 변경 시 페이지네이션 즉시 반영되도록 변경

### deleteGroupMemberById
serverFetcher로 변경 후 tag 적용
-> 멤버 삭제 시, team 페이지의 멤버 수 표시에 즉시 반영