### PR TITLE
[fix] #183 모달 오픈 시 스크롤바 밀림 이슈 처리 방식 gutter -> padding 변경

### DIFF
--- a/src/app/styles/dropdown.ts
+++ b/src/app/styles/dropdown.ts
@@ -1,3 +1,3 @@
-export const dropdownMenuStyle = 'mt-2 h-[80px] w-[120px]';
+export const dropdownMenuStyle = 'mt-2 w-[120px]';
 
 export const dropdownItemStyle = 'text-md-regular h-[39px] w-full';

--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -34,8 +34,6 @@
       sans-serif;
     color: var(--color-slate-50);
     background-color: var(--color-slate-900);
-
-    scrollbar-gutter: stable;
   }
 
   button {

--- a/src/hooks/useLockBackgroundScroll.ts
+++ b/src/hooks/useLockBackgroundScroll.ts
@@ -3,10 +3,15 @@ import { useEffect } from 'react';
 export const useLockBackgroundScroll = (shouldLock: boolean) => {
   useEffect(() => {
     if (shouldLock) {
+      const scrollbarWidth =
+        window.innerWidth - document.documentElement.clientWidth;
+
       document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
     }
     return () => {
       document.body.style.overflow = 'auto';
+      document.body.style.paddingRight = '';
     };
   }, [shouldLock]);
 };


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #183 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
### 스크롤바 밀림 이슈 해결
[기존] scrollbar-gutter: stable 전역 적용 -> 모달 오픈 시 스크롤바 영역 확보
[문제] 스크롤이 없는 화면에서도 스크롤바 영역이 보장됨 -> 불필요한 여백 발생
[해결]
- `useLockBackgroundScroll` 훅 수정
  - 윈도우 너비 - 사용자 화면 너비 계산식을 통해 스크롤바 너비 획득
shouldLock 상태에서 스크롤바 너비만큼의 padding을 동적 적용 처리
모달 닫힐 시 빈 padding값 리턴하여 불필요한 여백 방지

<br/>

### 드롭다운 css 수정
- dropdownMenuStyle 수정
  - 아이템 개수에 맞는 높이를 가지도록 h 고정값 제거
(TeamMenu, TaskListMenu에서 사용되는 드롭다운 공통 스타일)

## 📷 스크린샷
<!--- 없을 시 해당 목차는 삭제합니다. -->
![image](https://github.com/user-attachments/assets/23b4d32a-88d0-42b9-a817-3e9ea753f153)
수정 전 문제 발생 화면
<br/>
![image](https://github.com/user-attachments/assets/64158a71-c9c3-4d42-b43a-d1b5e51c65ad)
![image](https://github.com/user-attachments/assets/985108e6-d465-4dd0-a518-e205fc8a66d6)
수정 후 테스트 완료