### PR TITLE
[feat] #206 비밀번호 재설정 페이지 구현 / 요청에 따른 응답 처리 분기 / 코드 리뷰 반영

### DIFF
--- a/src/app/(auth)/login/_components/LoginForm/OpenPasswordResetModal.tsx
+++ b/src/app/(auth)/login/_components/LoginForm/OpenPasswordResetModal.tsx
@@ -53,7 +53,6 @@ export default function OpenPasswordResetModal({ ...props }) {
         // 존재하지 않는 유저 : User not found
         if (errorMessage.includes('User not found')) {
           toast.error('존재하지 않는 이메일입니다. 회원가입을 먼저 해주세요.');
-          router.push('/signup');
         } else {
           toast.error(`Error : ${error}`);
         }

--- a/src/app/(auth)/login/_components/LoginForm/OpenPasswordResetModal.tsx
+++ b/src/app/(auth)/login/_components/LoginForm/OpenPasswordResetModal.tsx
@@ -4,12 +4,13 @@ import ResetPasswordModal from '@/components/common/Modal/content/ResetPasswordM
 import { postResetPasswordToEmail } from '@/lib/apis/user';
 import { ResetPasswordToEmailBody } from '@/lib/apis/user/type';
 import { useModalStore } from '@/store/useModalStore';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
 
 export default function OpenPasswordResetModal({ ...props }) {
   const { openModal } = useModalStore();
+  const pathName = usePathname();
   const router = useRouter();
 
   useEffect(() => {
@@ -78,7 +79,6 @@ export default function OpenPasswordResetModal({ ...props }) {
                 onRequest: () => {},
               },
             },
-
             (() => <ResetPasswordModal />)()
           );
         }}

--- a/src/app/(auth)/login/_components/LoginForm/OpenPasswordResetModal.tsx
+++ b/src/app/(auth)/login/_components/LoginForm/OpenPasswordResetModal.tsx
@@ -4,14 +4,11 @@ import ResetPasswordModal from '@/components/common/Modal/content/ResetPasswordM
 import { postResetPasswordToEmail } from '@/lib/apis/user';
 import { ResetPasswordToEmailBody } from '@/lib/apis/user/type';
 import { useModalStore } from '@/store/useModalStore';
-import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
 
 export default function OpenPasswordResetModal({ ...props }) {
   const { openModal } = useModalStore();
-  const pathName = usePathname();
-  const router = useRouter();
 
   useEffect(() => {
     const unsubscribe = useModalStore.subscribe(
@@ -31,7 +28,7 @@ export default function OpenPasswordResetModal({ ...props }) {
       }
     );
     return () => {
-      unsubscribe(); // 언마운트, 구독 해제
+      unsubscribe();
     };
   }, []);
 
@@ -50,7 +47,7 @@ export default function OpenPasswordResetModal({ ...props }) {
       if (error instanceof Error) {
         const errorMessage = error.message;
 
-        // 존재하지 않는 유저 : User not found
+        // User not found
         if (errorMessage.includes('User not found')) {
           toast.error('존재하지 않는 이메일입니다. 회원가입을 먼저 해주세요.');
         } else {
@@ -71,7 +68,7 @@ export default function OpenPasswordResetModal({ ...props }) {
               title: '비밀번호 재설정',
               description: '비밀번호 재설정 링크를 보내드립니다.',
               button: {
-                formId: 'reset-password-form', // formId 연결
+                formId: 'reset-password-form', // form 연결
                 number: 2,
                 text: '링크 보내기',
                 // 기존 모달 컴포넌트의 onRequest 호출 방식과의 일관성을 위해 빈 함수 전달

--- a/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -37,7 +37,7 @@ const resetPasswordSchema = z
         path: ['password'],
         code: z.ZodIssueCode.custom,
         message:
-          '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.',
+          '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다∆.',
       });
     }
 
@@ -122,8 +122,7 @@ export default function ResetPasswordForm() {
 
     try {
       const token = searchParams.get('token');
-      if (!token) return; // null
-
+      if (!token) return; // null 방어 처리
       const res = await patchResetPassword({
         body: {
           passwordConfirmation: formValues.passwordConfirm,

--- a/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -24,7 +24,6 @@ const resetPasswordSchema = z
     const { password, passwordConfirm } = val;
 
     if (!password) {
-      // 비밀번호가 비어있음
       ctx.addIssue({
         path: ['password'],
         code: z.ZodIssueCode.custom,
@@ -32,7 +31,6 @@ const resetPasswordSchema = z
         fatal: true, // 조건 실패 시, 유효성 검사 중단
       });
     } else if (!validatePassword(password)) {
-      // 비밀번호가 입력은 되었지만, 유효하지 않음
       ctx.addIssue({
         path: ['password'],
         code: z.ZodIssueCode.custom,
@@ -42,7 +40,6 @@ const resetPasswordSchema = z
     }
 
     if (!passwordConfirm) {
-      // 비밀번호 확인이 비어있는 경우
       ctx.addIssue({
         path: ['passwordConfirm'],
         code: z.ZodIssueCode.custom,
@@ -50,7 +47,6 @@ const resetPasswordSchema = z
         fatal: true,
       });
     } else if (!validatePasswordConfirm({ password, passwordConfirm })) {
-      // 비밀번호 확인이 입력은 되었지만, 비밀번호와 일치하지 않음
       ctx.addIssue({
         path: ['passwordConfirm'],
         code: z.ZodIssueCode.custom,
@@ -122,7 +118,12 @@ export default function ResetPasswordForm() {
 
     try {
       const token = searchParams.get('token');
-      if (!token) return; // null 방어 처리
+      // early return
+      if (!token) {
+        toast.error('유효하지 않은 링크입니다. 다시 시도해주세요.');
+        return;
+      }
+
       const res = await patchResetPassword({
         body: {
           passwordConfirmation: formValues.passwordConfirm,

--- a/src/app/(auth)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(auth)/reset-password/ResetPasswordForm.tsx
@@ -37,7 +37,7 @@ const resetPasswordSchema = z
         path: ['password'],
         code: z.ZodIssueCode.custom,
         message:
-          '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다∆.',
+          '비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.',
       });
     }
 
@@ -103,7 +103,7 @@ export default function ResetPasswordForm() {
       } else {
         setFormErrors((prev) => ({
           ...prev,
-          [key]: '',
+          [key]: [],
         }));
       }
       setFormValues(newFormValues);

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,10 +1,17 @@
 import ResetPasswordForm from '@/app/(auth)/reset-password/ResetPasswordForm';
+import { Suspense } from 'react';
 
 export default function ResetPasswordPage() {
   return (
     <div className="flex h-[calc(100vh-60px)] justify-center pt-[140px]">
       <div className="flex flex-col">
-        <ResetPasswordForm />
+        <Suspense
+          fallback={
+            <div className="py-10 text-center text-slate-400">로딩 중...</div>
+          }
+        >
+          <ResetPasswordForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -37,7 +37,6 @@ export default function Modal() {
         button?.onRequest?.(requestBody);
         closeModal();
         isSubmittedRef.current = false;
-        console.log('handleRequest 실행');
         return;
       }
     }

--- a/src/lib/apis/user/index.ts
+++ b/src/lib/apis/user/index.ts
@@ -102,7 +102,7 @@ export async function postResetPasswordToEmail({
   });
 }
 
-// 이메일로 전달받은 링크에서 비밀번호 초기화 (PATCH /user/reset-password)
+// 비밀번호 재설정 페이지 : 이메일로 전달받은 링크에서 비밀번호 초기화 (PATCH /user/reset-password)
 export async function patchResetPassword({
   body,
 }: {
@@ -115,7 +115,7 @@ export async function patchResetPassword({
   });
 }
 
-// 비밀번호 변경 (PATCH /user/password)
+// 계정 설정 페이지 :  비밀번호 변경 (PATCH /user/password)
 export async function patchPassword({
   body,
 }: {


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #206 

<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->

### 비밀번호 재설정 폼 제출 및 API 호출
- 비밀번호 재설정 폼 제출 : useSearchParams 로 토큰을 가져와, patchResetPassword( ) 호출
- 요청 성공 : 성공 토스트 메시지 렌더링 및 /login 페이지로 라우팅 처리
- 요청 실패 : 실패 토스트 메시지 렌더링 및 에러 로그 출력
   - `비밀번호 재설정 링크카 만료되었습니다. 다시 요청해주세요.` 가 출력되도록 함
- 폼 제출 시점에 formErrors 객체 초기화로 기존의 에러 메시지가 남지 않도록 안전 장치 추가

### Suspense 도입으로 CSR bailout 빌드 에러 해결
> 상위 페이지 컴포넌트에서 props 로 내려주는 방법 사용 시, useSearchParams 를 페이지 컴포넌트에서 사용해야 하기 때문에 클라이언트 컴포넌트로 만들어야 함. 이는 **Next.js 의 공식 설계 철학** 과 위배되므로 Suspense 를 도입함. 
- Suspense 로 비동기 컴포넌트 (폼) 을 감싸 CSR bailout 빌드 에러 해결
- fallback 으로 빈 페이지가 렌더링 되지 않도록 조정
- token 이 null 인 경우에 대해 방어로직 추가 : `유효하지 않은 링크입니다. 다시 시도해주세요.` 토스트 메시지

### 이전 코드 리뷰 반영
- 코드 리뷰 반영 : 비밀번호 재설정 모달 api 요청 실패 시, `/signup` 라우팅 삭제 
(가입된 사용자가 오타를 내는 상황 고려)
- 디버깅용 콘솔 출력 삭제

### 기타
- API 함수 주석 개선 : pathResetPassword, patchPassword 

<br/>

## 📷 스크린샷
https://github.com/user-attachments/assets/0d93ecc3-40f4-4657-890f-289d1df993e5


<br/>

## 📢 공유 사항
<!--- 리뷰어가 알면 좋을 내용이나, 차후 작업 시 참고할 메모를 작성합니다. -->

<br/>

## 📚 참고 자료
<!--- 코드 이해에 도움이 되는 자료 및 설명을 추가합니다. -->
- [Missing Suspense boundary with useSearchParams](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)