### PR TITLE
[refactor] #186 모바일 환경 스크롤 UX 개선 목적 GradientScrollable 반응형 리팩토링

### DIFF
--- a/src/app/(team)/team/_components/TeamBanner/styles.ts
+++ b/src/app/(team)/team/_components/TeamBanner/styles.ts
@@ -20,7 +20,6 @@ export const teamBannerImgStyle =
 
 export const teamBannerTitleStyle = clsx(
   'text-xl-bold',
-  'relative flex-1',
-  'laptop:max-w-[800px] tablet:max-w-[460px] max-w-[245px]',
+  'relative flex-1 pr-3',
   'min-w-0'
 );

--- a/src/components/common/Scroll/GradientScrollable.tsx
+++ b/src/components/common/Scroll/GradientScrollable.tsx
@@ -1,6 +1,5 @@
-'use client';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 interface GradientScrollableProps {
   children: React.ReactNode;
@@ -20,7 +19,22 @@ const GradientScrollable = ({
   className,
   color = '#272e3f',
 }: GradientScrollableProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
   const [isScrollMove, setIsScrollMove] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      setIsOverflowing(el.scrollWidth > el.clientWidth);
+    });
+
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [children]);
 
   const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
     const { scrollLeft } = e.currentTarget;
@@ -30,6 +44,7 @@ const GradientScrollable = ({
   return (
     <div className="relative">
       <div
+        ref={scrollRef}
         onScroll={handleScroll}
         className={clsx(
           'scrollbar-hide overflow-x-auto whitespace-nowrap',
@@ -38,12 +53,17 @@ const GradientScrollable = ({
       >
         {children}
       </div>
-      <div
-        className={clsx(overflowTextGradientStyle, isScrollMove && 'opacity-0')}
-        style={{
-          background: `linear-gradient(to left, ${color}, transparent)`,
-        }}
-      />
+      {isOverflowing && (
+        <div
+          className={clsx(
+            overflowTextGradientStyle,
+            isScrollMove && 'opacity-0'
+          )}
+          style={{
+            background: `linear-gradient(to left, ${color}, transparent)`,
+          }}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
#186
<br/>

## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
![KakaoTalk_20250522_224530085](https://github.com/user-attachments/assets/bdaaaf9f-4954-4a56-9b6a-9505af65ce05)
### 이슈
- 기존 `GradientScrollable`은 단순히 부모 요소의 너비 기준으로 표시
- 때문에 사진과 같이 실제 text overflow가 발생하지 않아도 너비 끝에 표시되는 문제 발생

### 해결
- `el.scrollWidth > el.clientWidth` 비교를 통해 실제 overflow 여부 판단
- overflow가 발생할 때만 그라디언트가 표시되도록 useState로 관리
- ResizeObserver 도입해 브라우저 사이즈 변경 시에도 overflow 상태가 즉시 반영되도록 처리

<br/>

## 📷 스크린샷
<!--- 없을 시 해당 목차는 삭제합니다. -->
![녹음 2025-05-22 230445](https://github.com/user-attachments/assets/a18e58b9-f164-4429-91d4-40c770f6d630)
테스트 완료
<br/>