### PR TITLE
[refactor] 헤더 컴포넌트 - 소속 팀 없을 경우 고장나던 오류 수정

### DIFF
--- a/src/app/(team)/join-team/page.tsx
+++ b/src/app/(team)/join-team/page.tsx
@@ -5,14 +5,20 @@ import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/constants/routes';
 import JoinTeamForm from '@/app/(team)/_components/JoinTeamForm';
 import { postGroupInvitation } from '@/lib/apis/group';
-import { useMemberships } from '@/hooks/useMemberships';
 import { INVITATION_ERROR_MAP } from '@/utils/errorMap';
+import { useQuery } from '@tanstack/react-query';
+import { getUser } from '@/lib/apis/user';
 
 const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/;
 
 export default function JoinTeamPage() {
   const router = useRouter();
-  const { memberships } = useMemberships(true);
+
+  const { data: currentUser } = useQuery({
+    queryKey: ['currentUser'],
+    queryFn: () => getUser({}),
+    enabled: true,
+  });
 
   const [link, setLink] = useState('');
   const [error, setError] = useState<string>();
@@ -27,7 +33,8 @@ export default function JoinTeamPage() {
       setError('유효한 링크가 아닙니다.');
       return;
     }
-    const email = memberships[0]?.userEmail;
+    const email = currentUser?.email;
+
     if (!email) {
       setError('사용자 정보를 불러올 수 없습니다.');
       return;

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -42,7 +42,7 @@ export default function Header() {
       if (!fetchedUser) throw new Error('유저 정보를 가져오지 못했습니다');
       return fetchedUser;
     },
-    enabled: isLogin && Boolean(selectedGroup),
+    enabled: isLogin,
   });
 
   const handleLogout = () => {


### PR DESCRIPTION
## 🔗 이슈 번호
<!--- 관련 이슈 번호를 작성합니다. ex) #12 -->
Closes #218
## 📋 작업 사항
<!--- "어떻게"보다 "무엇"을 "왜" 수정했는지 설명하는 것이 좋습니다. -->
# 문제 상황 
-  소속팀이 없을 경우 헤더 표시 및 팀 참여 같은 기능이 정지된다

# 문제 원인
1. header/index 에서 **selectedGroup**이 있을 경우에만 유저 정보 가져오고 있음
- `isLogin && Boolean(selectedGroup)`
2.  join-team 에서 **membership.userEmail** 을 통해 유저 이메일 가져오고 있음
- `const email = memberships[0]?.userEmail`
# 문제 해결
1.  selectedGroup이 없어도 유저 정보 가져오기
- `enabled: isLogin`
2. currentUser.email 을 통해 유저 이메일 가져오기
- `const email = currentUser?.email`
